### PR TITLE
Search character detail skill and tripod

### DIFF
--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/gem/Gem.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/gem/Gem.kt
@@ -27,6 +27,7 @@ data class Effects(
 
 data class Gem(
     val type: String,
+    val grade: String,
     val level: Int,
     val gemIcon: String,
     val skillIcon: String,

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/gem/GemDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/gem/GemDetail.kt
@@ -9,6 +9,7 @@ class GemDetail(private val gemAndEffect: GemAndEffect) {
                 val type = if (effect.description.trim().split(" ").last() == "증가") "멸화" else "홍염"
                 Gem(
                     type = type,
+                    grade = gem.grade,
                     level = gem.level,
                     gemIcon = gem.icon,
                     skillIcon = effect.icon,

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkills.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkills.kt
@@ -35,6 +35,7 @@ data class Skills(
     val name: String,
     val level: Int,
     val tripods: List<Tripods>,
-    val rune: Rune?,
+    val rune: Rune? = null,
+    val runeTooltip: String? = null,
     val gem: Boolean,
 )

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkills.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkills.kt
@@ -36,5 +36,5 @@ data class Skills(
     val level: Int,
     val tripods: List<Tripods>,
     val rune: Rune?,
-    val gem: List<Map<String, String>>? = null,
+    val gem: Boolean,
 )

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkillsDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkillsDetail.kt
@@ -10,32 +10,22 @@ class CombatSkillsDetail(private val combatSkills: List<CombatSkills>) {
 
             val gemList = getSkillGem(skill)
 
-            if (gemList != null) {
-                val skills = Skills(
-                    icon = skill.icon,
-                    name = skill.name,
-                    level = skill.level,
-                    tripods = skill.tripods,
-                    rune = skill.rune,
-                    gem = gemList
-                )
-                skillList.add(skills)
-            } else {
-                val skills = Skills(
-                    icon = skill.icon,
-                    name = skill.name,
-                    level = skill.level,
-                    tripods = skill.tripods,
-                    rune = skill.rune
-                )
-                skillList.add(skills)
-            }
+            val skills = Skills(
+                icon = skill.icon,
+                name = skill.name,
+                level = skill.level,
+                tripods = skill.tripods,
+                rune = skill.rune,
+                gem = gemList
+            )
+            skillList.add(skills)
+
         }
 
         return skillList
     }
 
-    private fun getSkillGem(combatSkills: CombatSkills): List<Map<String, String>>? {
+    private fun getSkillGem(combatSkills: CombatSkills): Boolean {
         val tooltip = JsonParser.parseString(combatSkills.tooltip).asJsonObject
 
         for (index in 7..8) {
@@ -45,79 +35,12 @@ class CombatSkillsDetail(private val combatSkills: List<CombatSkills>) {
                 if (element.get("type").asString == "ItemPartBox") {
                     val value = element.getAsJsonObject("value")
                     if (value.get("Element_000").asString.contains("보석 효과")) {
-                        val gem = value.get("Element_001").asString
-
-                        return getGem(gem)
+                        return true
                     }
                 }
             }
         }
 
-        return null
-    }
-
-    private fun getGem(str: String) : MutableList<Map<String, String>> {
-        val gemList = mutableListOf<Map<String, String>>()
-
-        val regex = "(\\d+(\\.\\d+)?)% (증가|감소)".toRegex()
-        val matches = regex.findAll(str)
-
-        for (match in matches) {
-            val percent = match.groupValues[1].toDouble().toInt() // 숫자 부분을 추출하여 정수로 변환
-            val type = match.groupValues[3] // "증가" 또는 "감소" 부분을 추출
-
-            val result = if (type == "증가") {
-                calcAnnLevel(percent).toString() + "멸"
-            } else {
-                calcCriLevel(percent).toString() + "홍"
-            }
-
-            val icon = getGemIcon(result)
-
-            gemList.add(mapOf("name" to result, "icon" to icon))
-        }
-
-        return gemList
-    }
-
-    private fun calcAnnLevel(percent: Int): Int {
-        return when {
-            percent <= 24 -> percent / 3
-            percent <= 30 -> 9
-            else -> 10
-        }
-    }
-
-    private fun calcCriLevel(percent: Int): Int {
-        return percent / 2
-    }
-
-    private fun getGemIcon(gemInfo: String): String {
-        val baseUrl = "https://cdn-lostark.game.onstove.com/efui_iconatlas/use/"
-        val dotPNG = ".png"
-
-        return when (gemInfo) {
-            "1멸" -> baseUrl + "use_9_46" + dotPNG
-            "2멸" -> baseUrl + "use_9_47" + dotPNG
-            "3멸" -> baseUrl + "use_9_48" + dotPNG
-            "4멸" -> baseUrl + "use_9_49" + dotPNG
-            "5멸" -> baseUrl + "use_9_50" + dotPNG
-            "6멸" -> baseUrl + "use_9_51" + dotPNG
-            "7멸" -> baseUrl + "use_9_52" + dotPNG
-            "8멸" -> baseUrl + "use_9_53" + dotPNG
-            "9멸" -> baseUrl + "use_9_54" + dotPNG
-            "10멸" -> baseUrl + "use_9_55" + dotPNG
-            "1홍" -> baseUrl + "use_9_56" + dotPNG
-            "2홍" -> baseUrl + "use_9_57" + dotPNG
-            "3홍" -> baseUrl + "use_9_58" + dotPNG
-            "4홍" -> baseUrl + "use_9_59" + dotPNG
-            "5홍" -> baseUrl + "use_9_60" + dotPNG
-            "6홍" -> baseUrl + "use_9_61" + dotPNG
-            "7홍" -> baseUrl + "use_9_62" + dotPNG
-            "8홍" -> baseUrl + "use_9_63" + dotPNG
-            "9홍" -> baseUrl + "use_9_64" + dotPNG
-            "10홍" -> baseUrl + "use_9_65" + dotPNG
-            else -> ""
-        }
+        return false
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkillsDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/searchedInfo/skills/CombatSkillsDetail.kt
@@ -10,15 +10,27 @@ class CombatSkillsDetail(private val combatSkills: List<CombatSkills>) {
 
             val gemList = getSkillGem(skill)
 
-            val skills = Skills(
-                icon = skill.icon,
-                name = skill.name,
-                level = skill.level,
-                tripods = skill.tripods,
-                rune = skill.rune,
-                gem = gemList
-            )
-            skillList.add(skills)
+            if (skill.rune != null) {
+                val skills = Skills(
+                    icon = skill.icon,
+                    name = skill.name,
+                    level = skill.level,
+                    tripods = skill.tripods,
+                    rune = skill.rune,
+                    gem = gemList,
+                    runeTooltip = getRuneTooltip(skill.rune)
+                )
+                skillList.add(skills)
+            } else {
+                val skills = Skills(
+                    icon = skill.icon,
+                    name = skill.name,
+                    level = skill.level,
+                    tripods = skill.tripods,
+                    gem = gemList
+                )
+                skillList.add(skills)
+            }
 
         }
 
@@ -43,4 +55,11 @@ class CombatSkillsDetail(private val combatSkills: List<CombatSkills>) {
 
         return false
     }
+
+    private fun getRuneTooltip(rune: Rune): String? {
+        val tooltip = JsonParser.parseString(rune.tooltip).asJsonObject
+
+        return tooltip.getAsJsonObject("Element_002").getAsJsonObject("value").get("Element_001").asString
+    }
+
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/ui/theme/Color.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/ui/theme/Color.kt
@@ -35,6 +35,8 @@ val GreenQual = Color(0xFF70AD47)
 val YellowQual = Color(0xFFFFC000)
 val RedQual = Color(0xFFC00000)
 
+val EstherDark = Color(0xFF0C2E2C)
+val EsterColor = Color(0xFF2FABA8)
 val AncientDark = Color(0xFF3D3325)
 val AncientMiddle = Color(0xFFA88B6D)
 val AncientColor = Color(0xFFDCC999)
@@ -42,8 +44,12 @@ val RelicDark = Color(0xFF341A09)
 val RelicColor = Color(0xFFA24006)
 val LegendaryDark = Color(0xFF362003)
 val LegendaryColor = Color(0xFF9E5F04)
-val EstherDark = Color(0xFF0C2E2C)
-val EsterColor = Color(0xFF2FABA8)
+val EpicDark = Color(0xFF261931)
+val EpicColor = Color(0xFF480D5D)
+val RareDark = Color(0xFF111F2C)
+val RareColor = Color(0xFF113D5D)
+val UncommonDark = Color(0xFF18220B)
+val UncommonColor = Color(0xFF304911)
 
 val EstherBG = Brush.linearGradient(
     colors = listOf(
@@ -70,5 +76,26 @@ val LegendaryBG = Brush.linearGradient(
     colors = listOf(
         LegendaryDark,
         LegendaryColor,
+    )
+)
+
+val EpicBG = Brush.linearGradient(
+    colors = listOf(
+        EpicDark,
+        EpicColor
+    )
+)
+
+val UncommonBG = Brush.linearGradient(
+    colors = listOf(
+        UncommonDark,
+        UncommonColor
+    )
+)
+
+val RareBG = Brush.linearGradient(
+    colors = listOf(
+        RareDark,
+        RareColor
     )
 )

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
@@ -98,22 +98,13 @@ fun CharacterDetailScreen(
                 }
 
                 skills?.let { skillsList ->
-                    SkillDetailUI(characterDetail, skillsList)
+                    SkillDetailUI(characterDetail, skillsList, gems)
                 }
             }
         }
     }
 
 }
-
-
-//@OptIn(ExperimentalGlideComposeApi::class)
-//@Preview(showBackground = true)
-//@Composable
-//fun DefaultPreview() {
-//    GoldCalcTheme {
-//    }
-//}
 
 @Composable
 fun Levels(characterDetail: CharacterDetail) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
@@ -33,6 +33,7 @@ import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterDetail
 import com.hongmyeoun.goldcalc.model.searchedInfo.skills.Skills
+import com.hongmyeoun.goldcalc.ui.theme.BlackTransBG
 import com.hongmyeoun.goldcalc.ui.theme.LegendaryBG
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayTransBG
 import com.hongmyeoun.goldcalc.viewModel.charDetail.SkillDetailVM
@@ -165,16 +166,18 @@ private fun SkillIcon(it: Skills, isSimple: Boolean = false) {
                             }
                             TextChip(
                                 text = tripodSlots,
-                                customTextSize = 8.sp,
                                 borderless = true,
-                                customPadding = Modifier.padding(start = 1.dp, end = 1.dp)
+                                customTextSize = 8.sp,
+                                customBGColor = BlackTransBG,
+                                customPadding = Modifier.padding(start = 2.dp, end = 2.dp)
                             )
                             Spacer(modifier = Modifier.height(1.dp))
                             TextChip(
                                 text = tripodLevels,
-                                customTextSize = 8.sp,
                                 borderless = true,
-                                customPadding = Modifier.padding(start = 1.dp, end = 1.dp)
+                                customTextSize = 8.sp,
+                                customBGColor = BlackTransBG,
+                                customPadding = Modifier.padding(start = 2.dp, end = 2.dp)
                             )
                         }
                     }
@@ -287,14 +290,17 @@ private fun SkillSimple(skills: List<Skills>, viewModel: SkillDetailVM) {
                                 color = Color.DarkGray,
                                 shape = RoundedCornerShape(8.dp)
                             )
+                            .padding(4.dp)
                             .weight(1f),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         SkillIcon(it, true)
+                        Spacer(modifier = Modifier.width(4.dp))
                         Column(
                             horizontalAlignment = Alignment.Start
                         ) {
                             SkillSimpleTripods(it)
+                            Spacer(modifier = Modifier.height(4.dp))
                             SkillSimpleRuneAndGem(it, viewModel)
                         }
                     }
@@ -303,8 +309,8 @@ private fun SkillSimple(skills: List<Skills>, viewModel: SkillDetailVM) {
                     if (skills.size % 2 == 1) {
                         Spacer(
                             modifier = Modifier
-                            .width(1.dp)
-                            .weight(1f)
+                                .width(1.dp)
+                                .weight(1f)
                         )
                     }
                 }
@@ -320,9 +326,7 @@ private fun SkillSimpleTripods(it: Skills) {
     ) {
         Text(
             text = it.name,
-            color = Color.White,
-            fontWeight = FontWeight.Bold,
-            fontSize = 12.sp
+            style = titleBoldWhite12()
         )
     }
 }
@@ -338,12 +342,20 @@ private fun SkillSimpleRuneAndGem(
         it.rune?.let { rune ->
             TextChip(
                 text = rune.name,
-                customBGColor = viewModel.getGradeBG(rune.grade)
+                customBGColor = viewModel.getGradeBG(rune.grade),
+                borderless = true
             )
+            Spacer(modifier = Modifier.width(4.dp))
         }
         it.gem?.let { gems ->
             gems.forEach { gem ->
-                TextChip(text = gem["name"]!!)
+                val padding = if (gem["name"]!!.length >= 3 && gem.size > 1) {
+                    Modifier.padding(start = 4.dp, end = 4.dp, top = 2.dp, bottom = 2.dp)
+                } else {
+                    Modifier.padding(start = 6.dp, end = 6.dp, top = 2.dp, bottom = 2.dp)
+                }
+                TextChip(text = gem["name"]!!, borderless = true, customPadding = padding)
+                Spacer(modifier = Modifier.width(4.dp))
             }
         }
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
@@ -273,7 +273,7 @@ private fun SkillSimple(skills: List<Skills>) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(color = Color.Black)
+//            .background(color = Color.Black)
     ) {
         FlowRow(
             maxItemsInEachRow = 2,
@@ -298,6 +298,15 @@ private fun SkillSimple(skills: List<Skills>) {
                             SkillSimpleTripods(it)
                             SkillSimpleRuneAndGem(it)
                         }
+                    }
+                }
+                if (it == skills.last()) {
+                    if (skills.size % 2 == 1) {
+                        Spacer(
+                            modifier = Modifier
+                            .width(1.dp)
+                            .weight(1f)
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
@@ -2,7 +2,6 @@ package com.hongmyeoun.goldcalc.view.characterDetail
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,7 +34,10 @@ import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterDetail
 import com.hongmyeoun.goldcalc.model.searchedInfo.gem.Gem
 import com.hongmyeoun.goldcalc.model.searchedInfo.skills.Skills
 import com.hongmyeoun.goldcalc.ui.theme.BlackTransBG
+import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayTransBG
+import com.hongmyeoun.goldcalc.ui.theme.PurpleQual
+import com.hongmyeoun.goldcalc.view.common.noRippleClickable
 import com.hongmyeoun.goldcalc.viewModel.charDetail.SkillDetailVM
 
 @Composable
@@ -51,42 +53,41 @@ fun SkillDetailUI(
         modifier = Modifier
             .background(LightGrayTransBG, RoundedCornerShape(8.dp))
             .clip(RoundedCornerShape(8.dp))
+            .noRippleClickable { viewModel.onDetailClicked() }
             .padding(8.dp)
     ) {
-        Column(
-            modifier = Modifier.clickable { viewModel.onDetailClicked() }
+        Text(
+            text = "스킬",
+            style = titleTextStyle()
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
         ) {
-            Text(
-                text = "스킬",
-                style = titleTextStyle()
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-            ) {
-                characterDetail?.let { characterDetail ->
-                    TextChip(text = "스킬 포인트 ${characterDetail.usingSkillPoint}/${characterDetail.totalSkillPoint}")
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                val (fiveLevel, fourLevel) = viewModel.tripodLevel54(skills)
-
-                if (fiveLevel > 0) {
-                    TextChip(text = "Lv.5 x$fiveLevel")
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                if (fourLevel > 0) {
-                    TextChip(text = "Lv.4 x$fourLevel")
-                }
+            characterDetail?.let { characterDetail ->
+                TextChip(text = "스킬 포인트 ${characterDetail.usingSkillPoint}/${characterDetail.totalSkillPoint}")
+                Spacer(modifier = Modifier.width(8.dp))
             }
-            Spacer(modifier = Modifier.height(4.dp))
+            val (fiveLevel, fourLevel) = viewModel.tripodLevel54(skills)
 
-            if (isDetail) {
-                SkillDetail(skills, gemList, viewModel)
-            } else {
-                SkillSimple(skills, gemList, viewModel)
+            if (fiveLevel > 0) {
+                TextChip(text = "Lv.5 x$fiveLevel")
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            if (fourLevel > 0) {
+                TextChip(text = "Lv.4 x$fourLevel")
             }
         }
+        Spacer(modifier = Modifier.height(4.dp))
+
+        if (isDetail) {
+            SkillDetail(skills, gemList, viewModel)
+        } else {
+            SkillSimple(skills, gemList, viewModel)
+        }
+
     }
 }
 
@@ -97,12 +98,16 @@ private fun SkillDetail(
     viewModel: SkillDetailVM
 ) {
     Column(
-        modifier = Modifier.background(Color.Black)
+        modifier = Modifier
+            .padding(4.dp)
+            .background(
+                color = Color.Black,
+                shape = RoundedCornerShape(4.dp)
+            )
     ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(4.dp)
                 .background(
                     color = Color.DarkGray,
                     shape = RoundedCornerShape(4.dp)
@@ -110,14 +115,15 @@ private fun SkillDetail(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = "뭐 넣어야 될까",
-                color = Color.White,
-                fontWeight = FontWeight.Bold
+                text = "스킬 상세",
+                style = titleTextStyle()
             )
         }
+        Spacer(modifier = Modifier.height(4.dp))
 
         skills.forEach {
             SkillDetailRow(it, gemList, viewModel)
+            Spacer(modifier = Modifier.height(8.dp))
         }
     }
 }
@@ -128,15 +134,25 @@ private fun SkillDetailRow(
     gemList: List<Gem>?,
     viewModel: SkillDetailVM
 ) {
-    Row(
+    Column(
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(4.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .background(
+                color = LightGrayBG,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(8.dp)
     ) {
-        SkillIcon(it)
-        Spacer(modifier = Modifier.width(4.dp))
-        SkillTripods(it, viewModel)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SkillIcon(it)
+            Spacer(modifier = Modifier.width(4.dp))
+            SkillTripods(it, viewModel)
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+
         gemList?.let { gemList ->
             if (it.rune != null || it.gem) {
                 SkillRuneAndGem(it, gemList, viewModel)
@@ -148,13 +164,14 @@ private fun SkillDetailRow(
 @Composable
 @OptIn(ExperimentalGlideComposeApi::class)
 private fun SkillIcon(it: Skills, isSimple: Boolean = false) {
+    val iconSize = if (isSimple) 44.dp else 54.dp
     Box {
         Column {
             Row {
                 Box {
                     GlideImage(
                         modifier = Modifier
-                            .size(44.dp)
+                            .size(iconSize)
                             .border(
                                 width = 1.dp,
                                 color = Color.White,
@@ -198,39 +215,65 @@ private fun SkillIcon(it: Skills, isSimple: Boolean = false) {
             }
             Spacer(modifier = Modifier.height(6.dp))
         }
-        Box(modifier = Modifier.align(Alignment.BottomEnd)) {
-            TextChip(text = "${it.level}")
+        if (isSimple) {
+            Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+                TextChip(text = "${it.level}")
+            }
         }
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SkillTripods(it: Skills, viewModel: SkillDetailVM) {
     Column(horizontalAlignment = Alignment.Start) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TextChip(text = "${it.level}", customTextSize = 12.sp, customBGColor = PurpleQual)
+            Spacer(modifier = Modifier.width(8.dp))
+
             Text(
                 text = it.name,
                 color = Color.White,
                 fontWeight = FontWeight.Bold
             )
             Spacer(modifier = Modifier.width(8.dp))
+
             it.tripods.let { tripods ->
                 var selectedIndex = 0
 
-                tripods.forEach { tripod ->
-                    if (tripod.isSelected) {
-                        TextChip(
-                            text = "${tripod.slot}",
-                            borderless = true,
-                            customRoundedCornerSize = 8.dp,
-                            customBGColor = viewModel.getIndexColor(selectedIndex)
-                        )
-                        selectedIndex++
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+
+                    tripods.forEach { tripod ->
+                        if (tripod.isSelected) {
+                            TextChip(
+                                text = "${tripod.slot}",
+                                borderless = true,
+                                customTextSize = 14.sp,
+                                customRoundedCornerSize = 30.dp,
+                                customBGColor = viewModel.getIndexColor(selectedIndex)
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+
+                            selectedIndex++
+                        }
                     }
+
                 }
+
             }
         }
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Spacer(modifier = Modifier.height(8.dp))
+
+        FlowRow(
+            verticalArrangement = Arrangement.Center,
+            maxItemsInEachRow = 12
+        ) {
             it.tripods.let { tripods ->
                 var selectedIndex = 0
                 tripods.forEach { tripod ->
@@ -240,10 +283,12 @@ private fun SkillTripods(it: Skills, viewModel: SkillDetailVM) {
                             borderless = true,
                             customBGColor = viewModel.getIndexColor(selectedIndex)
                         )
+                        Spacer(modifier = Modifier.width(4.dp))
                         Text(
                             text = tripod.name,
-                            style = normalTextStyle(color = viewModel.getIndexColor(selectedIndex))
+                            style = normalTextStyle(color = viewModel.getIndexColor(selectedIndex), fontSize = 12.sp)
                         )
+                        Spacer(modifier = Modifier.width(4.dp))
                         selectedIndex++
                     }
                 }
@@ -265,16 +310,44 @@ private fun SkillRuneAndGem(
     ) {
         it.rune?.let { rune ->
             Row(verticalAlignment = Alignment.CenterVertically) {
-                TextChip(text = rune.name)
                 GlideImage(
                     modifier = Modifier
+                        .size(54.dp)
+                        .border(
+                            width = 1.dp,
+                            color = Color.White,
+                            shape = RoundedCornerShape(10.dp)
+                        )
                         .background(
                             brush = viewModel.getItemBG(rune.grade),
-                            shape = RoundedCornerShape(30.dp)
-                        ),
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .clip(RoundedCornerShape(10.dp)),
                     model = rune.icon,
+                    contentScale = ContentScale.Crop,
                     contentDescription = "룬"
                 )
+
+                Column {
+                    Row {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        TextChip(text = rune.grade, customTextSize = 12.sp, borderless = true, customBGColor = viewModel.getGradeBG(rune.grade))
+                        TextChip(text = rune.name, customTextSize = 12.sp, borderless = true, customBGColor = LightGrayTransBG)
+                    }
+                    it.runeTooltip?.let { tooltip ->
+                        Box(
+                            modifier = Modifier
+                                .padding(start = 8.dp)
+                                .fillMaxWidth()
+                                .padding(8.dp)
+                        ) {
+                            Text(
+                                text = tooltip,
+                                style = normalTextStyle()
+                            )
+                        }
+                    }
+                }
             }
         }
 
@@ -282,22 +355,52 @@ private fun SkillRuneAndGem(
             val equipGemList = viewModel.gemFiltering(gemList, it)
 
             equipGemList.forEach { gem ->
-                val gemType = viewModel.typeTrans(gem)
-
                 Spacer(modifier = Modifier.height(4.dp))
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    TextChip(text = "${gem.level}${gemType}")
                     GlideImage(
                         modifier = Modifier
+                            .size(54.dp)
+                            .border(
+                                width = 1.dp,
+                                color = Color.White,
+                                shape = RoundedCornerShape(10.dp)
+                            )
                             .background(
                                 brush = viewModel.getItemBG(gem.grade),
-                                shape = RoundedCornerShape(30.dp)
-                            ),
+                                shape = RoundedCornerShape(10.dp)
+                            )
+                            .clip(RoundedCornerShape(10.dp)),
                         model = gem.gemIcon,
+                        contentScale = ContentScale.Crop,
                         contentDescription = "보석"
                     )
+                    Column {
+                        Row {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            TextChip(
+                                text = "${gem.level}레벨 ${gem.type}의 보석",
+                                customTextSize = 12.sp,
+                                borderless = true,
+                                customBGColor = viewModel.getGradeBG(gem.grade)
+                            )
+                        }
+                        Box(
+                            modifier = Modifier
+                                .padding(start = 8.dp, end = 24.dp)
+                                .background(LightGrayBG, RoundedCornerShape(4.dp))
+                                .fillMaxWidth()
+                                .padding(8.dp)
+                        ) {
+                            Text(
+                                text = gem.effect,
+                                style = normalTextStyle()
+                            )
+                        }
+
+                    }
+
                 }
             }
         }
@@ -387,8 +490,7 @@ private fun SkillSimpleRuneAndGem(
         if (it.gem) {
             val equipGemList = gemList.filter { gem -> gem.skill == it.name }
             equipGemList.forEach { gem ->
-                val gemType = if (gem.type.contains('멸')) '멸' else '홍'
-                val gemInfo = "${gem.level}${gemType}"
+                val gemInfo = viewModel.gemInfo(gem)
 
                 val padding = if (gemInfo.length >= 3 && equipGemList.size > 1) {
                     Modifier.padding(start = 4.dp, end = 4.dp, top = 2.dp, bottom = 2.dp)

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
@@ -424,7 +424,7 @@ private fun SkillSimple(skills: List<Skills>, gemList: List<Gem>?, viewModel: Sk
                         modifier = Modifier
                             .padding(4.dp)
                             .background(
-                                color = Color.DarkGray,
+                                color = LightGrayBG ,
                                 shape = RoundedCornerShape(8.dp)
                             )
                             .padding(4.dp)

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
@@ -135,7 +135,8 @@ private fun SkillDetailRow(
         verticalAlignment = Alignment.CenterVertically
     ) {
         SkillIcon(it)
-        SkillTripods(it)
+        Spacer(modifier = Modifier.width(4.dp))
+        SkillTripods(it, viewModel)
         gemList?.let { gemList ->
             if (it.rune != null || it.gem) {
                 SkillRuneAndGem(it, gemList, viewModel)
@@ -204,7 +205,7 @@ private fun SkillIcon(it: Skills, isSimple: Boolean = false) {
 }
 
 @Composable
-private fun SkillTripods(it: Skills) {
+private fun SkillTripods(it: Skills, viewModel: SkillDetailVM) {
     Column(horizontalAlignment = Alignment.Start) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -214,23 +215,36 @@ private fun SkillTripods(it: Skills) {
             )
             Spacer(modifier = Modifier.width(8.dp))
             it.tripods.let { tripods ->
+                var selectedIndex = 0
+
                 tripods.forEach { tripod ->
                     if (tripod.isSelected) {
-                        TextChip(text = "${tripod.slot}")
+                        TextChip(
+                            text = "${tripod.slot}",
+                            borderless = true,
+                            customRoundedCornerSize = 8.dp,
+                            customBGColor = viewModel.getIndexColor(selectedIndex)
+                        )
+                        selectedIndex++
                     }
                 }
             }
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
             it.tripods.let { tripods ->
+                var selectedIndex = 0
                 tripods.forEach { tripod ->
                     if (tripod.isSelected) {
-                        TextChip(text = "${tripod.level}")
+                        TextChip(
+                            text = "${tripod.level}",
+                            borderless = true,
+                            customBGColor = viewModel.getIndexColor(selectedIndex)
+                        )
                         Text(
                             text = tripod.name,
-                            color = Color.White,
-                            fontSize = 10.sp
+                            style = normalTextStyle(color = viewModel.getIndexColor(selectedIndex))
                         )
+                        selectedIndex++
                     }
                 }
             }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/SkillDetailUI.kt
@@ -82,7 +82,7 @@ fun SkillDetailUI(
             if (isDetail) {
                 SkillDetail(skills)
             } else {
-                SkillSimple(skills)
+                SkillSimple(skills, viewModel)
             }
         }
     }
@@ -269,11 +269,10 @@ private fun SkillRuneAndGem(it: Skills) {
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun SkillSimple(skills: List<Skills>) {
+private fun SkillSimple(skills: List<Skills>, viewModel: SkillDetailVM) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-//            .background(color = Color.Black)
     ) {
         FlowRow(
             maxItemsInEachRow = 2,
@@ -296,7 +295,7 @@ private fun SkillSimple(skills: List<Skills>) {
                             horizontalAlignment = Alignment.Start
                         ) {
                             SkillSimpleTripods(it)
-                            SkillSimpleRuneAndGem(it)
+                            SkillSimpleRuneAndGem(it, viewModel)
                         }
                     }
                 }
@@ -329,12 +328,18 @@ private fun SkillSimpleTripods(it: Skills) {
 }
 
 @Composable
-private fun SkillSimpleRuneAndGem(it: Skills) {
+private fun SkillSimpleRuneAndGem(
+    it: Skills,
+    viewModel: SkillDetailVM
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically
     ) {
         it.rune?.let { rune ->
-            TextChip(text = "(${rune.grade})${rune.name}")
+            TextChip(
+                text = rune.name,
+                customBGColor = viewModel.getGradeBG(rune.grade)
+            )
         }
         it.gem?.let { gems ->
             gems.forEach { gem ->

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
@@ -55,6 +55,15 @@ class SkillDetailVM: ViewModel() {
         return itemBG
     }
 
+    fun getIndexColor(index: Int): Color {
+        val indexColor = when(index) {
+            0 -> GreenQual
+            1 -> PurpleQual
+            else -> OrangeQual
+        }
+        return indexColor
+    }
+
     fun gemFiltering(gemList: List<Gem>, skill: Skills): List<Gem> {
         return gemList.filter { gem -> gem.skill == skill.name }
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
@@ -1,14 +1,21 @@
 package com.hongmyeoun.goldcalc.viewModel.charDetail
 
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.util.fastSumBy
 import androidx.lifecycle.ViewModel
+import com.hongmyeoun.goldcalc.model.searchedInfo.gem.Gem
 import com.hongmyeoun.goldcalc.model.searchedInfo.skills.Skills
 import com.hongmyeoun.goldcalc.ui.theme.BlueQual
+import com.hongmyeoun.goldcalc.ui.theme.EpicBG
 import com.hongmyeoun.goldcalc.ui.theme.GreenQual
+import com.hongmyeoun.goldcalc.ui.theme.LegendaryBG
 import com.hongmyeoun.goldcalc.ui.theme.OrangeQual
 import com.hongmyeoun.goldcalc.ui.theme.PurpleQual
+import com.hongmyeoun.goldcalc.ui.theme.RareBG
+import com.hongmyeoun.goldcalc.ui.theme.RelicBG
 import com.hongmyeoun.goldcalc.ui.theme.RelicColor
+import com.hongmyeoun.goldcalc.ui.theme.UncommonBG
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -35,5 +42,24 @@ class SkillDetailVM: ViewModel() {
             else -> GreenQual
         }
         return itemBG
+    }
+
+    fun getItemBG(grade: String): Brush {
+        val itemBG = when (grade) {
+            "유물" -> RelicBG
+            "전설" -> LegendaryBG
+            "영웅" -> EpicBG
+            "희귀" -> RareBG
+            else -> UncommonBG
+        }
+        return itemBG
+    }
+
+    fun gemFiltering(gemList: List<Gem>, skill: Skills): List<Gem> {
+        return gemList.filter { gem -> gem.skill == skill.name }
+    }
+
+    fun typeTrans(gem: Gem): Char {
+        return if (gem.type.contains('멸')) '멸' else '홍'
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
@@ -1,8 +1,14 @@
 package com.hongmyeoun.goldcalc.viewModel.charDetail
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.util.fastSumBy
 import androidx.lifecycle.ViewModel
 import com.hongmyeoun.goldcalc.model.searchedInfo.skills.Skills
+import com.hongmyeoun.goldcalc.ui.theme.BlueQual
+import com.hongmyeoun.goldcalc.ui.theme.GreenQual
+import com.hongmyeoun.goldcalc.ui.theme.OrangeQual
+import com.hongmyeoun.goldcalc.ui.theme.PurpleQual
+import com.hongmyeoun.goldcalc.ui.theme.RelicColor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -18,5 +24,16 @@ class SkillDetailVM: ViewModel() {
         val fiveLevel = skills.fastSumBy { skill -> skill.tripods.count { tripod -> tripod.isSelected && tripod.level == 5 } }
         val fourLevel = skills.fastSumBy { skill -> skill.tripods.count { tripod -> tripod.isSelected && tripod.level == 4 } }
         return Pair(fiveLevel, fourLevel)
+    }
+
+    fun getGradeBG(grade: String): Color {
+        val itemBG = when (grade) {
+            "유물" -> RelicColor
+            "전설" -> OrangeQual
+            "영웅" -> PurpleQual
+            "희귀" -> BlueQual
+            else -> GreenQual
+        }
+        return itemBG
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/SkillDetailVM.kt
@@ -58,7 +58,7 @@ class SkillDetailVM: ViewModel() {
     fun getIndexColor(index: Int): Color {
         val indexColor = when(index) {
             0 -> GreenQual
-            1 -> PurpleQual
+            1 -> BlueQual
             else -> OrangeQual
         }
         return indexColor
@@ -68,7 +68,11 @@ class SkillDetailVM: ViewModel() {
         return gemList.filter { gem -> gem.skill == skill.name }
     }
 
-    fun typeTrans(gem: Gem): Char {
+    private fun typeTrans(gem: Gem): Char {
         return if (gem.type.contains('멸')) '멸' else '홍'
+    }
+
+    fun gemInfo(gem: Gem): String {
+        return "${gem.level}${typeTrans(gem)}"
     }
 }


### PR DESCRIPTION
# 스킬 UI 업데이트
- 간단한 스킬 표시와 자세한 스킬표시에 대한 UI를 변경
- 보석과 맵핑되어있지 않아 보석 아이콘을 URL과 직접연결하는 이상한 로직을 사용했던것을 수정
- 보석, 룬 배경색 변경

## UI 변경

### 간단한 스킬 설명
|변경전|변경후|
|:---:|:---:|
|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/caef0045-7eac-4bce-b080-0f4e79c93b4a)|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/956dfadf-33e5-432f-be22-8d3a6341b799)|

변경전
- 스킬선택, 트라이포드를 나타내는 TextChip 색이 Black
- 룬에 이름이 길어져서 보석을 두개 끼는 경우 UI가 깨짐
- 스킬이 홀수인 경우 마지막 스킬은 짝을 이루지 못해 배경색이 그대로 다 보이게 됨

변경후
- 스킬선택, 트라이포드를 나타내는 TextChip 색을 TransBlack으로 변경
- 룬에 이름이 긴 문제를 룬의 등급과 동일한 색으로 등급을 표기
    - 10멸을 두개 사용할때 나오는 UI 깨짐 현상을 customPadding으로 해결
- 스킬이 홀수인 경우 빈칸을 추가해 짝을 이루게 하므로 해결

### 자세한스킬 설명
|변경전|변경후|
|:---:|:---:|
|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/f49aa095-237c-461b-8c7e-a43207585d5e)|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/2bf4c1cc-bccb-46ea-b68f-9b4faa88edf0)|

변경전
- TextChip에 Border가 있어서 조잡함
- 글씨크기가 작아 보이지 않음
- 현재 장착중인 보석을 보여주는 것이 아니라 온라인상 있는 보석 이미지를 보여주므로 2티어, 이벤트 보석은 표기가 안됨
- 보석과 룬에 배경색이 전부 Relic

변경후
- TextChip에 Border를 제거하고 색을 추가
    - 선택한 스킬의 번호와 트라이포드 레벨의 색을 일치시키므로 가시성 증진
    - padding 추가로 보기 좋게 편집
- 글씨크기를 키우기 위해 룬과 보석의 위치를 변경하고 전체적인 크기를 키움
    - 문제점이 생김 트라이포드 이름이 길어지면 다음줄로 넘어가 지지만, 트라이포드 레벨까지 갖고가지 않음
- 보석에 대한 정보를 끌고와서 스킬이름과 매칭시켜 장착중인 보석에 대한 정보를 사용
    - 모든것과 상관없이 장착중인 보석을 보여주게 됨
- 보석과 룬에 배경색을 그 등급에 맞게 변경
    - 새로운 색들을 추가
    - 새로운 data class 파라미터들 추가