### PR TITLE
Search character detail combat stat

### DIFF
--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
@@ -85,9 +85,16 @@ fun CharacterDetailScreen(
                     .fillMaxSize()
                     .padding(4.dp)
             ) {
-                engravings?.let { skillEngravings ->
-                    EngravingDetailUI(skillEngravings)
+                Row {
+                    val rowWeight = Modifier.weight(1f)
+                    CombatStatDetailUI(rowWeight, charDetail)
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    engravings?.let { skillEngravings ->
+                        EngravingDetailUI(rowWeight, skillEngravings)
+                    }
                 }
+                Spacer(modifier = Modifier.height(16.dp))
 
                 equipment?.let { equipmentList ->
                     val equipmentVM = EquipmentDetailVM(equipmentList)

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CombatStatDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CombatStatDetailUI.kt
@@ -1,0 +1,133 @@
+package com.hongmyeoun.goldcalc.view.characterDetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterDetail
+import com.hongmyeoun.goldcalc.ui.theme.BlackTransBG
+import com.hongmyeoun.goldcalc.ui.theme.LightGrayTransBG
+import com.hongmyeoun.goldcalc.ui.theme.OrangeQual
+import com.hongmyeoun.goldcalc.viewModel.charDetail.CombatStatDetailVM
+
+@Composable
+fun CombatStatDetailUI(
+    modifier: Modifier,
+    charDetail: CharacterDetail,
+    viewModel: CombatStatDetailVM = viewModel()
+) {
+    val showDialog by viewModel.showDialog.collectAsState()
+
+    if (showDialog) {
+//        EngravingDescription(skillEngravings, viewModel)
+    }
+
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp)),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CombatStatSimple(
+            charDetail = charDetail,
+            default = true
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        CombatStatSimple(
+            charDetail = charDetail,
+            default = false
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun CombatStatSimple(
+    charDetail: CharacterDetail,
+    default: Boolean
+) {
+    val title = if (default) "기본 특성" else "전투 특성"
+    val typeList = if (default) listOf("공격력", "최대 생명력") else listOf("치명", "특화", "제압", "신속", "인내", "숙련")
+    val maxItem = if (default) 1 else 2
+
+    Column(
+        modifier = Modifier
+            .background(LightGrayTransBG, RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(8.dp))
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BlackTransBG)
+                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
+        ) {
+            Text(text = title, style = titleTextStyle(fontSize = 13.sp))
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+
+        FlowRow(
+            maxItemsInEachRow = maxItem
+        ) {
+            charDetail.stats.forEach { stat ->
+                if (stat.type in typeList) {
+                    Row(
+                        modifier = Modifier
+                            .padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
+                            .weight(1f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            text = stat.type,
+                            style = normalTextStyle(color = OrangeQual, fontSize = 12.sp),
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            text = stat.value,
+                            style = normalTextStyle(fontSize = 12.sp),
+                            textAlign = TextAlign.End
+                        )
+                    }
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Icon(
+            modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally).size(16.dp),
+            imageVector = Icons.Default.KeyboardArrowDown,
+            tint = Color.White,
+            contentDescription = "더보기"
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+    }
+}

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CombatStatDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CombatStatDetailUI.kt
@@ -9,11 +9,15 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,15 +27,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterDetail
 import com.hongmyeoun.goldcalc.ui.theme.BlackTransBG
+import com.hongmyeoun.goldcalc.ui.theme.ImageBG
+import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayTransBG
 import com.hongmyeoun.goldcalc.ui.theme.OrangeQual
+import com.hongmyeoun.goldcalc.view.common.noRippleClickable
 import com.hongmyeoun.goldcalc.viewModel.charDetail.CombatStatDetailVM
 
 @Composable
@@ -40,10 +49,21 @@ fun CombatStatDetailUI(
     charDetail: CharacterDetail,
     viewModel: CombatStatDetailVM = viewModel()
 ) {
-    val showDialog by viewModel.showDialog.collectAsState()
+    val showDefaultDialog by viewModel.showDefaultDialog.collectAsState()
+    val showCombatDialog by viewModel.showCombatDialog.collectAsState()
 
-    if (showDialog) {
-//        EngravingDescription(skillEngravings, viewModel)
+    if (showDefaultDialog) {
+        StatsDetails(
+            charDetail = charDetail,
+            viewModel = viewModel,
+            default = true
+        )
+    } else if (showCombatDialog) {
+        StatsDetails(
+            charDetail = charDetail,
+            viewModel = viewModel,
+            default = false
+        )
     }
 
     Column(
@@ -53,13 +73,15 @@ fun CombatStatDetailUI(
     ) {
         CombatStatSimple(
             charDetail = charDetail,
-            default = true
+            default = true,
+            onClick = { viewModel.onDefaultClicked() }
         )
         Spacer(modifier = Modifier.height(16.dp))
 
         CombatStatSimple(
             charDetail = charDetail,
-            default = false
+            default = false,
+            onClick = { viewModel.onCombatClicked() }
         )
     }
 }
@@ -68,7 +90,8 @@ fun CombatStatDetailUI(
 @Composable
 private fun CombatStatSimple(
     charDetail: CharacterDetail,
-    default: Boolean
+    default: Boolean,
+    onClick: () -> Unit
 ) {
     val title = if (default) "기본 특성" else "전투 특성"
     val typeList = if (default) listOf("공격력", "최대 생명력") else listOf("치명", "특화", "제압", "신속", "인내", "숙련")
@@ -95,6 +118,7 @@ private fun CombatStatSimple(
         Spacer(modifier = Modifier.height(4.dp))
 
         FlowRow(
+            modifier = Modifier.noRippleClickable { onClick() },
             maxItemsInEachRow = maxItem
         ) {
             charDetail.stats.forEach { stat ->
@@ -128,11 +152,94 @@ private fun CombatStatSimple(
         Spacer(modifier = Modifier.height(4.dp))
 
         Icon(
-            modifier = Modifier.fillMaxWidth().align(Alignment.CenterHorizontally).size(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally)
+                .size(16.dp),
             imageVector = Icons.Default.KeyboardArrowDown,
             tint = Color.White,
             contentDescription = "더보기"
         )
         Spacer(modifier = Modifier.height(4.dp))
+    }
+}
+
+@Composable
+fun StatsDetails(
+    charDetail: CharacterDetail,
+    viewModel: CombatStatDetailVM,
+    default: Boolean
+) {
+    val configuration = LocalConfiguration.current
+    val screenHeight = configuration.screenHeightDp.dp
+    val maxColumnHeight = (screenHeight * 0.8f) // 화면 높이의 80%
+
+    val title = if (default) "기본 특성" else "전투 특성"
+    val typeList = if (default) listOf("공격력", "최대 생명력") else listOf("치명", "특화", "제압", "신속", "인내", "숙련")
+
+    Dialog(
+        onDismissRequest = { viewModel.onDismissRequest() }
+    ) {
+        Column(
+            modifier = Modifier
+                .background(ImageBG, RoundedCornerShape(16.dp))
+                .heightIn(max = maxColumnHeight)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Text(
+                text = title,
+                style = titleTextStyle()
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Divider()
+            Spacer(modifier = Modifier.height(16.dp))
+
+            charDetail.stats.forEach { stat ->
+                if (stat.type in typeList) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stat.type,
+                            style = normalTextStyle(color = OrangeQual, fontSize = 15.sp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Column(
+                        modifier = Modifier
+                            .background(LightGrayBG, RoundedCornerShape(4.dp))
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                    ) {
+                        stat.tooltip.forEach { description ->
+                            if (!description.contains("않습니다.")) {
+                                Row(verticalAlignment = Alignment.Top) {
+                                    Text(
+                                        modifier = Modifier.padding(end = 4.dp),
+                                        text = "·",
+                                        style = normalTextStyle(fontSize = 12.sp)
+                                    )
+
+                                    Text(
+                                        modifier = Modifier.weight(1f),
+                                        text = viewModel.removeHTMLTags(description),
+                                        style = normalTextStyle(fontSize = 10.sp),
+                                        lineHeight = 14.sp,
+                                    )
+                                }
+                            }
+                            if (description != stat.tooltip.last()) {
+                                Spacer(modifier = Modifier.height(4.dp))
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CombatStatDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CombatStatDetailUI.kt
@@ -85,7 +85,12 @@ private fun CombatStatSimple(
                 .background(BlackTransBG)
                 .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp)
         ) {
-            Text(text = title, style = titleTextStyle(fontSize = 13.sp))
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = title,
+                style = titleTextStyle(fontSize = 13.sp),
+                textAlign = TextAlign.Center
+            )
         }
         Spacer(modifier = Modifier.height(4.dp))
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/EngravingDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/EngravingDetailUI.kt
@@ -35,6 +35,7 @@ import com.hongmyeoun.goldcalc.viewModel.charDetail.EngravingDetailVM
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun EngravingDetailUI(
+    modifier: Modifier,
     skillEngravings: List<SkillEngravings>,
     viewModel: EngravingDetailVM = viewModel()
 ) {
@@ -45,7 +46,7 @@ fun EngravingDetailUI(
     }
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .background(LightGrayTransBG, RoundedCornerShape(8.dp))
             .clip(RoundedCornerShape(8.dp))
             .padding(16.dp),

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/EngravingDetailUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/EngravingDetailUI.kt
@@ -72,7 +72,11 @@ fun EngravingDetailUI(
                 Spacer(modifier = Modifier.width(8.dp))
 
                 Column {
-                    Text(text = it.name, style = titleTextStyle(fontSize = 15.sp))
+                    val textSize = if (it.name.length > 8) 10.sp else if (it.name.length > 7) 13.sp else 15.sp
+                    Text(
+                        text = it.name,
+                        style = titleTextStyle(fontSize = textSize)
+                    )
                     if (it.awakenEngravingsPoint != null) {
                         Text(text = "각인서 ${it.awakenEngravingsPoint}", style = normalTextStyle(fontSize = 12.sp))
                     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/equipment/Equipments.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/equipment/Equipments.kt
@@ -72,11 +72,13 @@ fun EquipmentDetails(
                     option = equipment.elixirFirstOption,
                     viewModel = viewModel
                 )
-                ElixirLevelOptionRow(
-                    level = equipment.elixirSecondLevel,
-                    option = equipment.elixirSecondOption,
-                    viewModel = viewModel
-                )
+                if (equipment.elixirSecondLevel.isNotEmpty()) {
+                    ElixirLevelOptionRow(
+                        level = equipment.elixirSecondLevel,
+                        option = equipment.elixirSecondOption,
+                        viewModel = viewModel
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/CombatStatDetailVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/CombatStatDetailVM.kt
@@ -1,0 +1,33 @@
+package com.hongmyeoun.goldcalc.viewModel.charDetail
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class CombatStatDetailVM: ViewModel() {
+    private val _showDialog = MutableStateFlow(false)
+    val showDialog: StateFlow<Boolean> = _showDialog
+    fun onDismissRequest() {
+        _showDialog.value = false
+    }
+
+    fun onClicked() {
+        _showDialog.value = true
+    }
+
+    // 물약 및 원정대 레벨로 추가된 스텟
+    fun potionPlusStat(tooltip: List<String>): Int {
+        // "물약 및 원정대 레벨" 포함된 부분과 숫자를 추출
+        val regex = Regex("물약 및 원정대 레벨.*?<font color='#99ff99'>(\\d+)</font>")
+
+        for (text in tooltip) {
+            val matchResult = regex.find(text)
+            if (matchResult != null) {
+                return matchResult.groupValues[1].toInt() // 숫자만 추출하면 되므로
+            }
+        }
+
+        return 0
+    }
+
+}

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/CombatStatDetailVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/charDetail/CombatStatDetailVM.kt
@@ -5,14 +5,22 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class CombatStatDetailVM: ViewModel() {
-    private val _showDialog = MutableStateFlow(false)
-    val showDialog: StateFlow<Boolean> = _showDialog
+    private val _showDefaultDialog = MutableStateFlow(false)
+    val showDefaultDialog: StateFlow<Boolean> = _showDefaultDialog
     fun onDismissRequest() {
-        _showDialog.value = false
+        _showDefaultDialog.value = false
+        _showCombatDialog.value = false
     }
 
-    fun onClicked() {
-        _showDialog.value = true
+    fun onDefaultClicked() {
+        _showDefaultDialog.value = true
+    }
+
+    private val _showCombatDialog = MutableStateFlow(false)
+    val showCombatDialog: StateFlow<Boolean> = _showCombatDialog
+
+    fun onCombatClicked() {
+        _showCombatDialog.value = true
     }
 
     // 물약 및 원정대 레벨로 추가된 스텟
@@ -30,4 +38,7 @@ class CombatStatDetailVM: ViewModel() {
         return 0
     }
 
+    fun removeHTMLTags(htmlStr: String): String {
+        return htmlStr.replace(Regex("<.*?>"), "").trim()
+    }
 }


### PR DESCRIPTION
# 특성 표기
기본 특성과 전투 특성을 표기

## UI
|기본|상세|
|:---:|:---:|
|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/9b51fda7-9634-4596-b792-825f7d8077aa)|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/db920d1a-14bc-49a2-a7f0-c7d690cf242b)|

## 문제였던점
description을 표기할때 html 태그를 없애니 가장 앞 글자가 공백이 되어버림, 눈으로 보기에 다음줄로 넘어갔을때 정렬이 안된 것 처럼 보임.
trim()을 통해 해결

## 추가할 점
스텟은 다양한 스텟들의 합산으로 표기가 되어있음
예를 들어 특화스텟이 957이라면
```
(32 +37) + 491 + 298 + 99 = 957
(물약 + 카드) + 악세 + 팔찌 = 총합
```
이런 식을 따름
이때 캐릭터가 펫을 장착하고 있다면 또 다른 값으로 계산됨

```
신속이 1486일 경우
((28 + 37) + 495 + 295 +197 + 200 + 99) * 1.1 = 1486.1
((물약 + 카드) + 악세 + 팔찌) * 펫효과(1.1) = 총합
```
그런데 펫 효과는 사람마다 다 값이 다름 (보통 10%), 그리고 API에서 펫착용 여부를 알려주지 않음. 직접 계산해야함

```
펫유무 판별
(물약 + 카드) -> value
value + 악세 + 팔찌 != 총합 -> 펫효과가 있음
```
이런 계산값에서 API는 '카드' 값은 제공해주지 않음. 직접 계산해야함

```
펫 X
카드 = 총합 - (악세 + 팔찌) - 물약

펫 O
카드 = (총합/1.1) - (악세 + 팔찌) - 물약
```
이렇게 카드를 따로 계산하고 Text를 buildAnotation을 사용해 여러 색으로 표기하면 될 것 같음
그러기 위해서 악세서리 값들을 함수로 끌고와야함
그리고 악세서리의 특성과 제공되는 특성을 매칭시켜야함
또한 팔찌도 동일하게 적용

# 결론
이 모든걸 해도 7월 10일 로스트아크 게임이 시즌3가 되면서 장신구와 특성, 펫에 많은 변화가 찾아오기 때문에 바뀐 뒤에 추가하는 방향으로 가기



