### PR TITLE
UI color gold setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,4 +99,7 @@ dependencies {
     // Glide
     implementation ("com.github.bumptech.glide:compose:1.0.0-beta01")
 
+    // Navigation Bar Animation
+    implementation ("com.canopas.compose-animated-navigationbar:bottombar:1.0.1")
+
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/MainActivity.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/MainActivity.kt
@@ -6,8 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,9 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Divider
 import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -29,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -63,6 +58,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+//        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         setContent {
             GoldCalcTheme {
                 val navController = rememberNavController()
@@ -161,25 +159,7 @@ fun LoadingScreen() {
     }
 }
 
-@Composable
-fun SimplephaseInfo(
-    isCheck: Boolean,
-    modifier: Modifier,
-    raidName: String,
-    phaseInfo: @Composable () -> Unit
-) {
-    if (isCheck) {
-        Column(modifier = modifier) {
-            Text(
-                text = raidName,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(4.dp))
 
-            phaseInfo()
-        }
-    }
-}
 
 
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -88,7 +89,8 @@ fun CharacterDetailUI(
 
                 Spacer(modifier = Modifier.width(32.dp).weight(0.5f))
             }
-        }
+        },
+        contentWindowInsets = WindowInsets(0.dp)
     ) {
         CharacterDetailScreen(charName = charName, paddingValues = it)
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/characterDetail/CharacterDetail.kt
@@ -46,6 +46,7 @@ import androidx.navigation.NavHostController
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterDetail
+import com.hongmyeoun.goldcalc.model.roomDB.character.Character
 import com.hongmyeoun.goldcalc.ui.theme.ImageBG
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayTransBG
@@ -180,6 +181,17 @@ fun Levels(characterDetail: CharacterDetail) {
 }
 
 @Composable
+fun Levels(character: Character) {
+    Row {
+        CharLevel("전투", character.characterLevel.toString())
+        Spacer(modifier = Modifier.width(16.dp))
+
+        CharLevel("원정대", character.expeditionLevel.toString())
+    }
+}
+
+
+@Composable
 private fun CharLevel(title: String, level: String) {
     Column {
         Text(
@@ -284,6 +296,18 @@ fun Extra(characterDetail: CharacterDetail) {
     Spacer(modifier = Modifier.height(6.dp))
 
     ExtraInfo("PVP", characterDetail.pvpGradeName)
+    Spacer(modifier = Modifier.height(16.dp))
+}
+
+@Composable
+fun Extra(character: Character) {
+    ExtraInfo("길드", character.guildName)
+    Spacer(modifier = Modifier.height(6.dp))
+
+    ExtraInfo("영지", "Lv.${character.townLevel} ${character.townName}")
+    Spacer(modifier = Modifier.height(6.dp))
+
+    ExtraInfo("PVP", character.pvpGradeName)
     Spacer(modifier = Modifier.height(16.dp))
 }
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/PhaseView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/PhaseView.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DividerDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +29,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
+import com.hongmyeoun.goldcalc.ui.theme.GreenQual
+import com.hongmyeoun.goldcalc.ui.theme.ImageBG
+import com.hongmyeoun.goldcalc.ui.theme.RedQual
 import com.hongmyeoun.goldcalc.view.main.formatWithCommas
 import com.hongmyeoun.goldcalc.view.main.goldImage
 
@@ -42,7 +45,7 @@ fun PhaseUI(
     onClearClicked: (Boolean) -> Unit,
     onMoreClicked: (Boolean) -> Unit
 ) {
-    val difficultyColor = if (difficulty == "하드") Color.Red else MaterialTheme.colorScheme.primary
+    val difficultyColor = if (difficulty == "하드") RedQual else GreenQual
 
     Row(
         modifier = Modifier
@@ -62,7 +65,8 @@ fun PhaseUI(
             onClick = { onLevelClicked() },
             enabled = clearCheck || moreCheck,
             colors = ButtonDefaults.outlinedButtonColors(
-                contentColor = difficultyColor
+                contentColor = difficultyColor,
+                disabledContentColor = Color.LightGray
             )
         ) {
             Text(text = difficulty)
@@ -80,7 +84,11 @@ fun PhaseUI(
         ) {
             Checkbox(
                 checked = clearCheck,
-                onCheckedChange = { onClearClicked(it) }
+                onCheckedChange = { onClearClicked(it) },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = ImageBG,
+                    uncheckedColor = Color.White
+                )
             )
             Text(text = "클리어")
         }
@@ -90,7 +98,11 @@ fun PhaseUI(
         ) {
             Checkbox(
                 checked = moreCheck,
-                onCheckedChange = { onMoreClicked(it) }
+                onCheckedChange = { onMoreClicked(it) },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = ImageBG,
+                    uncheckedColor = Color.White
+                )
             )
             Text(text = "더보기")
         }
@@ -512,7 +524,7 @@ fun PhaseUIOneDifficulty(
     onClearClicked: (Boolean) -> Unit,
     onMoreClicked: (Boolean) -> Unit
 ) {
-    val difficultyColor = if (difficulty == "하드") Color.Red else MaterialTheme.colorScheme.primary
+    val difficultyColor = if (difficulty == "하드") RedQual else GreenQual
 
     Row(
         modifier = Modifier
@@ -533,6 +545,7 @@ fun PhaseUIOneDifficulty(
             enabled = clearCheck || moreCheck,
             colors = ButtonDefaults.outlinedButtonColors(
                 contentColor = difficultyColor,
+                disabledContentColor = Color.LightGray
             )
         ) {
             Text(text = difficulty)
@@ -550,7 +563,11 @@ fun PhaseUIOneDifficulty(
         ) {
             Checkbox(
                 checked = clearCheck,
-                onCheckedChange = { onClearClicked(it) }
+                onCheckedChange = { onClearClicked(it) },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = ImageBG,
+                    uncheckedColor = Color.White
+                )
             )
             Text(text = "클리어")
         }
@@ -560,7 +577,11 @@ fun PhaseUIOneDifficulty(
         ) {
             Checkbox(
                 checked = moreCheck,
-                onCheckedChange = { onMoreClicked(it) }
+                onCheckedChange = { onMoreClicked(it) },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = ImageBG,
+                    uncheckedColor = Color.White
+                )
             )
             Text(text = "더보기")
         }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/PhaseView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/PhaseView.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
-import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.view.main.formatWithCommas
+import com.hongmyeoun.goldcalc.view.main.goldImage
 
 @Composable
 fun PhaseUI(
@@ -403,7 +403,7 @@ fun TotalGoldText(totalGold: Int, isDark: Boolean = isSystemInDarkTheme()) {
                 .weight(0.3f)
                 .size(16.dp),
             alignment = Alignment.Center,
-            model = R.drawable.gold_coin,
+            model = goldImage(totalGold),
             contentDescription = "골드 아이콘"
         )
     }
@@ -441,7 +441,7 @@ fun PhaseGoldText(
                 .weight(0.3f)
                 .size(16.dp),
             alignment = Alignment.Center,
-            model = R.drawable.gold_coin,
+            model = goldImage(phaseGold),
             contentDescription = "골드 아이콘"
         )
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/RaidCard.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/RaidCard.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
-import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.view.main.formatWithCommas
+import com.hongmyeoun.goldcalc.view.main.goldImage
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
@@ -48,7 +48,7 @@ fun RaidCard(
         ) {
             GlideImage(
                 modifier = Modifier.size(25.dp),
-                model = R.drawable.gold_coins,
+                model = goldImage(totalGold),
                 contentDescription = "골드 아이콘"
             )
             Spacer(modifier = Modifier.width(8.dp))

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/AbyssDungeonView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/AbyssDungeonView.kt
@@ -2,20 +2,11 @@ package com.hongmyeoun.goldcalc.view.goldCheck.cardContent
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.view.goldCheck.FourPhaseBoss
 import com.hongmyeoun.goldcalc.view.goldCheck.ThreePhaseBoss
@@ -33,26 +24,21 @@ fun AbyssDungeon(viewModel: AbyssDungeonVM) {
         targetValue = if (ivoryTowerRotated) 180f else 0f,
         animationSpec = tween(500)
     )
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(16.dp).border(1.dp, Color.LightGray, RoundedCornerShape(16.dp)),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            RaidBossCheck(
-                name = "카양겔",
-                modifier = Modifier.weight(1f),
-                checked = viewModel.kayangelCheck,
-                onCheckedChange = { viewModel.onKayangelCheck() }
-            )
 
-            RaidBossCheck(
-                name = "상아탑",
-                modifier = Modifier.weight(1f),
-                checked = viewModel.ivoryCheck,
-                onCheckedChange = { viewModel.onIvoryCheck() }
-            )
-        }
+    RaidCheckLists(maxItem = 2) { modifier ->
+        RaidBossCheck(
+            name = "카양겔",
+            modifier = modifier,
+            checked = viewModel.kayangelCheck,
+            onCheckedChange = { viewModel.onKayangelCheck() }
+        )
+
+        RaidBossCheck(
+            name = "상아탑",
+            modifier = modifier,
+            checked = viewModel.ivoryCheck,
+            onCheckedChange = { viewModel.onIvoryCheck() }
+        )
     }
 
     if (viewModel.kayangelCheck) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/CommandBossView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/CommandBossView.kt
@@ -2,23 +2,12 @@ package com.hongmyeoun.goldcalc.view.goldCheck.cardContent
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import com.hongmyeoun.goldcalc.R
-import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.view.goldCheck.FourPhaseBoss
 import com.hongmyeoun.goldcalc.view.goldCheck.FourPhaseBossLastHard
 import com.hongmyeoun.goldcalc.view.goldCheck.ThreePhaseBoss
@@ -56,36 +45,48 @@ fun CommandRaid(
         targetValue = if (kamenRotated) 180f else 0f, animationSpec = tween(500)
     )
 
+    RaidCheckLists(maxItem = 3) { modifier ->
+        RaidBossCheck(
+            name = "발탄",
+            modifier = modifier,
+            checked = viewModel.valtanCheck,
+            onCheckedChange = { viewModel.onValtanCheck() }
+        )
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp)
-            .background(LightGrayBG, RoundedCornerShape(16.dp))
-            .border(1.dp, Color.LightGray, RoundedCornerShape(16.dp)),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            RaidBossCheck(
-                name = "발탄",
-                modifier = Modifier.weight(1f),
-                checked = viewModel.valtanCheck,
-                onCheckedChange = { viewModel.onValtanCheck() })
+        RaidBossCheck(
+            name = "비아",
+            modifier = modifier,
+            checked = viewModel.biaCheck,
+            onCheckedChange = { viewModel.onBiaCheck() }
+        )
 
-            RaidBossCheck(name = "비아", modifier = Modifier.weight(1f), checked = viewModel.biaCheck, onCheckedChange = { viewModel.onBiaCheck() })
+        RaidBossCheck(
+            name = "쿠크",
+            modifier = modifier,
+            checked = viewModel.koukuCheck,
+            onCheckedChange = { viewModel.onKoukuCheck() }
+        )
 
-            RaidBossCheck(name = "쿠크", modifier = Modifier.weight(1f), checked = viewModel.koukuCheck, onCheckedChange = { viewModel.onKoukuCheck() })
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            RaidBossCheck(name = "아브", modifier = Modifier.weight(1f), checked = viewModel.abreCheck, onCheckedChange = { viewModel.onAbreCheck() })
+        RaidBossCheck(
+            name = "아브",
+            modifier = modifier,
+            checked = viewModel.abreCheck,
+            onCheckedChange = { viewModel.onAbreCheck() }
+        )
 
-            RaidBossCheck(name = "일리", modifier = Modifier.weight(1f), checked = viewModel.illiCheck, onCheckedChange = { viewModel.onIlliCheck() })
+        RaidBossCheck(
+            name = "일리",
+            modifier = modifier,
+            checked = viewModel.illiCheck,
+            onCheckedChange = { viewModel.onIlliCheck() }
+        )
 
-            RaidBossCheck(name = "카멘", modifier = Modifier.weight(1f), checked = viewModel.kamenCheck, onCheckedChange = { viewModel.onKamenCheck() })
-        }
+        RaidBossCheck(
+            name = "카멘",
+            modifier = modifier,
+            checked = viewModel.kamenCheck,
+            onCheckedChange = { viewModel.onKamenCheck() }
+        )
     }
 
     if (viewModel.valtanCheck) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/CommandBossView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/CommandBossView.kt
@@ -2,6 +2,7 @@ package com.hongmyeoun.goldcalc.view.goldCheck.cardContent
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.hongmyeoun.goldcalc.R
+import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.view.goldCheck.FourPhaseBoss
 import com.hongmyeoun.goldcalc.view.goldCheck.FourPhaseBossLastHard
 import com.hongmyeoun.goldcalc.view.goldCheck.ThreePhaseBoss
@@ -59,6 +61,7 @@ fun CommandRaid(
         modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp)
+            .background(LightGrayBG, RoundedCornerShape(16.dp))
             .border(1.dp, Color.LightGray, RoundedCornerShape(16.dp)),
     ) {
         Row(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/Common.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/Common.kt
@@ -12,16 +12,19 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
+import com.hongmyeoun.goldcalc.ui.theme.ImageBG
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
@@ -72,8 +75,15 @@ fun RaidBossCheck(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
-        Text(text = name, fontWeight = FontWeight.Bold)
+        Text(text = name, fontWeight = FontWeight.Bold, color = Color.White)
         Spacer(modifier = Modifier.width(8.dp))
-        Checkbox(checked = checked, onCheckedChange = { onCheckedChange() })
+        Checkbox(
+            checked = checked,
+            onCheckedChange = { onCheckedChange() },
+            colors = CheckboxDefaults.colors(
+                checkedColor = ImageBG,
+                uncheckedColor = Color.White // 테두리 색 변경해줌
+            )
+        )
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/Common.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/Common.kt
@@ -1,7 +1,11 @@
 package com.hongmyeoun.goldcalc.view.goldCheck.cardContent
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -25,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.hongmyeoun.goldcalc.ui.theme.ImageBG
+import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
@@ -47,6 +52,10 @@ fun RaidCardUI(
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(
             defaultElevation = 6.dp
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = LightGrayBG,
+            contentColor = Color.White
         )
     ) {
         if (!isRotated) {
@@ -85,5 +94,23 @@ fun RaidBossCheck(
                 uncheckedColor = Color.White // 테두리 색 변경해줌
             )
         )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun RaidCheckLists(
+    maxItem: Int,
+    checkList: @Composable (Modifier)-> Unit
+) {
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .background(LightGrayBG, RoundedCornerShape(16.dp))
+            .border(1.dp, Color.LightGray, RoundedCornerShape(16.dp)),
+        maxItemsInEachRow = maxItem
+    ) {
+        checkList(Modifier.weight(1f))
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/EpicRaidView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/EpicRaidView.kt
@@ -2,20 +2,11 @@ package com.hongmyeoun.goldcalc.view.goldCheck.cardContent
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.view.goldCheck.TwoPhaseBossNoHard
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.EpicRaidVM
@@ -27,19 +18,14 @@ fun EpicRaid(viewModel: EpicRaidVM) {
         targetValue = if (behemothRotated) 180f else 0f,
         animationSpec = tween(500)
     )
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(16.dp).border(1.dp, Color.LightGray, RoundedCornerShape(16.dp)),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            RaidBossCheck(
-                name = "베히모스",
-                modifier = Modifier.weight(1f),
-                checked = viewModel.beheCheck,
-                onCheckedChange = { viewModel.onBeheCheck() }
-            )
-        }
+
+    RaidCheckLists(maxItem = 2) { modifier ->
+        RaidBossCheck(
+            name = "베히모스",
+            modifier = modifier,
+            checked = viewModel.beheCheck,
+            onCheckedChange = { viewModel.onBeheCheck() }
+        )
     }
 
     if (viewModel.beheCheck) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/KazerothRaidView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/cardContent/KazerothRaidView.kt
@@ -2,20 +2,11 @@ package com.hongmyeoun.goldcalc.view.goldCheck.cardContent
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.view.goldCheck.TwoPhaseBoss
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.KazerothRaidVM
@@ -29,19 +20,13 @@ fun KazerothRaid(viewModel: KazerothRaidVM) {
         animationSpec = tween(500)
     )
 
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(16.dp).border(1.dp, Color.LightGray, RoundedCornerShape(16.dp)),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            RaidBossCheck(
-                name = "에키드나",
-                modifier = Modifier.weight(1f),
-                checked = viewModel.echiCheck,
-                onCheckedChange = { viewModel.onEchiCheck() }
-            )
-        }
+    RaidCheckLists(maxItem = 2) { modifier ->
+        RaidBossCheck(
+            name = "에키드나",
+            modifier = modifier,
+            checked = viewModel.echiCheck,
+            onCheckedChange = { viewModel.onEchiCheck() }
+        )
     }
 
     if (viewModel.echiCheck) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSetting.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSetting.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import com.hongmyeoun.goldcalc.ui.theme.ImageBG
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.AbyssDungeonVM
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.CommandBossVM
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.EpicRaidVM
@@ -28,6 +29,7 @@ fun GoldSetting(
     Scaffold(
         modifier = Modifier
             .fillMaxSize(),
+        containerColor = ImageBG,
         topBar = { GoldSettingTopBar(viewModel, navController) },
         bottomBar = { GoldSettingBottomBar(viewModel, cbVM, adVM, kzVM, epVM, navController) }
     ) { paddingValues ->

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSetting.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSetting.kt
@@ -1,6 +1,7 @@
 package com.hongmyeoun.goldcalc.view.goldCheck.setting
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,6 +23,8 @@ fun GoldSetting(
     kzVM: KazerothRaidVM,
     epVM: EpicRaidVM,
 ) {
+    val scrollState = rememberLazyListState()
+
     LaunchedEffect(cbVM.totalGold, adVM.totalGold, kzVM.totalGold, epVM.totalGold, viewModel.plusGold, viewModel.minusGold, viewModel.selectedTab) {
         viewModel.updateTotalGold(cbVM.totalGold, adVM.totalGold, kzVM.totalGold, epVM.totalGold)
     }
@@ -30,10 +33,10 @@ fun GoldSetting(
         modifier = Modifier
             .fillMaxSize(),
         containerColor = ImageBG,
-        topBar = { GoldSettingTopBar(viewModel, navController) },
+        topBar = { GoldSettingTopBar(viewModel, navController, scrollState) },
         bottomBar = { GoldSettingBottomBar(viewModel, cbVM, adVM, kzVM, epVM, navController) }
     ) { paddingValues ->
-        GoldSettingContent(paddingValues, viewModel, cbVM, adVM, kzVM, epVM)
+        GoldSettingContent(paddingValues, viewModel, scrollState, cbVM, adVM, kzVM, epVM)
     }
 
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingBottomBar.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingBottomBar.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -53,10 +52,8 @@ import com.bumptech.glide.integration.compose.GlideImage
 import com.hongmyeoun.goldcalc.model.roomDB.character.Character
 import com.hongmyeoun.goldcalc.ui.theme.GreenQual
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
-import com.hongmyeoun.goldcalc.ui.theme.LightGrayTransBG
 import com.hongmyeoun.goldcalc.view.characterDetail.normalTextStyle
 import com.hongmyeoun.goldcalc.view.characterDetail.titleTextStyle
-import com.hongmyeoun.goldcalc.view.common.noRippleClickable
 import com.hongmyeoun.goldcalc.view.main.formatWithCommas
 import com.hongmyeoun.goldcalc.view.main.goldImage
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.AbyssDungeonVM
@@ -65,7 +62,6 @@ import com.hongmyeoun.goldcalc.viewModel.goldCheck.EpicRaidVM
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.GoldSettingVM
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.KazerothRaidVM
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GoldSettingBottomBar(
     viewModel: GoldSettingVM,
@@ -76,61 +72,7 @@ fun GoldSettingBottomBar(
     navController: NavHostController
 ) {
     if (viewModel.expanded) {
-        val configuration = LocalConfiguration.current
-        val screenHeight = configuration.screenHeightDp.dp
-        val maxColumnHeight = (screenHeight * 0.80f)
-
-        val character by viewModel.character.collectAsState()
-
-        ModalBottomSheet(
-            modifier = Modifier
-                .heightIn(max = maxColumnHeight),
-            onDismissRequest = { viewModel.close() },
-            containerColor = LightGrayBG,
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Column(
-                    modifier = Modifier
-                        .heightIn(max = maxColumnHeight)
-                        .wrapContentHeight()
-                        .verticalScroll(rememberScrollState())
-                ) {
-
-                    if (cbVM.valtanCheck || cbVM.biaCheck || cbVM.koukuCheck || cbVM.abreCheck || cbVM.illiCheck || cbVM.kamenCheck) {
-                        SimpleCommandRaidInfo(cbVM)
-                    }
-
-                    if (adVM.kayangelCheck || adVM.ivoryCheck) {
-                        SimpleAbyssDungeonInfo(adVM)
-                    }
-
-                    if (kzVM.echiCheck) {
-                        SimpleKazerothRaidInfo(kzVM)
-                    }
-
-                    if (epVM.beheCheck) {
-                        SimpleEpicRaidInfo(epVM)
-                    }
-
-                    if ((viewModel.plusGold.toIntOrNull() ?: 0) > 0) {
-                        SimpleETCInfo(viewModel)
-                    }
-
-                    Box(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
-                        BottomBarTexts(
-                            character = character,
-                            viewModel = viewModel,
-                            navController = navController,
-                            onDoneClicked = { viewModel.onDoneClick(cbVM, adVM, kzVM, epVM) }
-                        )
-                    }
-                }
-
-            }
-
-        }
+        SimpleSummary(viewModel, cbVM, adVM, kzVM, epVM, navController)
     } else {
         BottomBar(
             viewModel = viewModel,
@@ -140,37 +82,33 @@ fun GoldSettingBottomBar(
 }
 
 @Composable
-fun SimpleSummary(
+@OptIn(ExperimentalMaterial3Api::class)
+private fun SimpleSummary(
+    viewModel: GoldSettingVM,
     cbVM: CommandBossVM,
     adVM: AbyssDungeonVM,
     kzVM: KazerothRaidVM,
     epVM: EpicRaidVM,
-    navController: NavHostController,
-    viewModel: GoldSettingVM
+    navController: NavHostController
 ) {
     val configuration = LocalConfiguration.current
     val screenHeight = configuration.screenHeightDp.dp
     val maxColumnHeight = (screenHeight * 0.80f)
+
     val character by viewModel.character.collectAsState()
 
-    Column(modifier = Modifier.background(LightGrayTransBG)) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .weight(1f)
-                .noRippleClickable { viewModel.close() }
-        )
-
+    ModalBottomSheet(
+        modifier = Modifier
+            .heightIn(max = maxColumnHeight),
+        onDismissRequest = { viewModel.close() },
+        containerColor = LightGrayBG,
+        dragHandle = {
+            DragDerivationIcon()
+        }
+    ) {
         Column(
-            modifier = Modifier
-                .background(
-                    color = LightGrayBG,
-                    shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
-                ),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            DragDerivationIcon()
-
             Column(
                 modifier = Modifier
                     .heightIn(max = maxColumnHeight)
@@ -203,12 +141,16 @@ fun SimpleSummary(
                         character = character,
                         viewModel = viewModel,
                         navController = navController,
-                        onDoneClicked = { viewModel.onDoneClick(cbVM, adVM, kzVM, epVM) }
+                        onDoneClicked = {
+                            viewModel.close()
+                            viewModel.onDoneClick(cbVM, adVM, kzVM, epVM)
+                        }
                     )
                 }
             }
 
         }
+
     }
 }
 
@@ -511,7 +453,6 @@ private fun BottomBar(
                 shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
             )
             .clip(shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
-//            .noRippleClickable { viewModel.expand() }
             .pointerInput(Unit) {
                 detectDragGestures(
                     onDrag = { change, dragAmount ->

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingBottomBar.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingBottomBar.kt
@@ -41,9 +41,9 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
-import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.SimplephaseInfo
 import com.hongmyeoun.goldcalc.view.main.formatWithCommas
+import com.hongmyeoun.goldcalc.view.main.goldImage
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.AbyssDungeonVM
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.CommandBossVM
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.EpicRaidVM
@@ -454,11 +454,11 @@ private fun BottomBar(
                 modifier = Modifier.weight(3f),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                BottomGoldText(beforeOrAfter = "전", gold = character?.weeklyGold?.formatWithCommas())
+                BottomGoldText(beforeOrAfter = "전", gold = character?.weeklyGold?:0)
                 Spacer(modifier = Modifier.width(8.dp))
                 Icon(imageVector = Icons.Default.ArrowForward, contentDescription = "화살표")
                 Spacer(modifier = Modifier.width(12.dp))
-                BottomGoldText(beforeOrAfter = "후", gold = viewModel.totalGold.formatWithCommas())
+                BottomGoldText(beforeOrAfter = "후", gold = viewModel.totalGold)
             }
             Row(horizontalArrangement = Arrangement.End) {
                 OutlinedButton(
@@ -492,7 +492,7 @@ private fun BottomBar(
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
-fun BottomGoldText(beforeOrAfter: String, gold: String?) {
+fun BottomGoldText(beforeOrAfter: String, gold: Int) {
     Column {
         Text(text = "변경 $beforeOrAfter")
         Row(
@@ -500,12 +500,12 @@ fun BottomGoldText(beforeOrAfter: String, gold: String?) {
         ) {
             GlideImage(
                 modifier = Modifier.size(18.dp),
-                model = R.drawable.gold_coins,
+                model = goldImage(gold),
                 contentDescription = "골드 이미지",
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = gold?:"0",
+                text = gold.formatWithCommas(),
                 fontSize = 14.sp
             )
         }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingBottomBar.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingBottomBar.kt
@@ -2,7 +2,6 @@ package com.hongmyeoun.goldcalc.view.goldCheck.setting
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,12 +17,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowForward
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,6 +28,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -42,6 +40,11 @@ import androidx.navigation.NavHostController
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.hongmyeoun.goldcalc.SimplephaseInfo
+import com.hongmyeoun.goldcalc.ui.theme.GreenQual
+import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
+import com.hongmyeoun.goldcalc.view.characterDetail.normalTextStyle
+import com.hongmyeoun.goldcalc.view.characterDetail.titleTextStyle
+import com.hongmyeoun.goldcalc.view.common.noRippleClickable
 import com.hongmyeoun.goldcalc.view.main.formatWithCommas
 import com.hongmyeoun.goldcalc.view.main.goldImage
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.AbyssDungeonVM
@@ -427,41 +430,62 @@ private fun BottomBar(
     val borderPadding = if (viewModel.expanded) Modifier
         .border(1.dp, Color.LightGray)
         .padding(start = 16.dp, end = 8.dp, bottom = 16.dp, top = 16.dp) else Modifier.padding(start = 16.dp, end = 8.dp, bottom = 16.dp)
-    val arrowIcon = if (viewModel.expanded) Icons.Default.KeyboardArrowDown else Icons.Default.KeyboardArrowUp
 
-    Column {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = LightGrayBG,
+                shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+            )
+            .clip(shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+            .noRippleClickable { viewModel.expand() }
+            .then(borderPadding)
+    ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(top = 12.dp)
         ) {
-            Icon(
+            Box(
                 modifier = Modifier
-                    .height(20.dp)
-                    .align(Alignment.Center),
-                imageVector = arrowIcon,
-                contentDescription = "펼치기, 접기"
+                    .width(64.dp)
+                    .height(4.dp)
+                    .background(
+                        color = Color.LightGray,
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                    .align(Alignment.Center)
             )
         }
+        Spacer(modifier = Modifier.height(16.dp))
+
         Row(
             modifier = Modifier
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.background)
-                .clickable { viewModel.expand() }
-                .then(borderPadding),
+                .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Row(
                 modifier = Modifier.weight(3f),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                BottomGoldText(beforeOrAfter = "전", gold = character?.weeklyGold?:0)
+                BottomGoldText(beforeOrAfter = "전", gold = character?.weeklyGold ?: 0)
                 Spacer(modifier = Modifier.width(8.dp))
-                Icon(imageVector = Icons.Default.ArrowForward, contentDescription = "화살표")
+
+                Icon(
+                    imageVector = Icons.Default.ArrowForward,
+                    tint = Color.White,
+                    contentDescription = "화살표"
+                )
                 Spacer(modifier = Modifier.width(12.dp))
+
                 BottomGoldText(beforeOrAfter = "후", gold = viewModel.totalGold)
             }
             Row(horizontalArrangement = Arrangement.End) {
                 OutlinedButton(
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = Color.White
+                    ),
                     onClick = {
                         navController.navigate("Main") {
                             popUpTo("Check/{charName}") {
@@ -474,6 +498,10 @@ private fun BottomBar(
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = GreenQual,
+                        contentColor = Color.White
+                    ),
                     onClick = {
                         onDoneClicked()
                         navController.navigate("Main") {
@@ -494,7 +522,10 @@ private fun BottomBar(
 @Composable
 fun BottomGoldText(beforeOrAfter: String, gold: Int) {
     Column {
-        Text(text = "변경 $beforeOrAfter")
+        Text(
+            text = "변경 $beforeOrAfter",
+            style = titleTextStyle(fontSize = 18.sp)
+        )
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -506,7 +537,7 @@ fun BottomGoldText(beforeOrAfter: String, gold: Int) {
             Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = gold.formatWithCommas(),
-                fontSize = 14.sp
+                style = normalTextStyle(fontSize = 14.sp)
             )
         }
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
@@ -1,10 +1,15 @@
 package com.hongmyeoun.goldcalc.view.goldCheck.setting
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -103,6 +108,8 @@ fun GoldSettingContent(
     val screenHeight = configuration.screenHeightDp.dp
     val maxColumnHeight = (screenHeight * 0.93f) // 화면 높이의 80%
 
+    val showDetail by viewModel.showDetail.collectAsState()
+
     if (isLoading) {
         LoadingScreen()
     } else {
@@ -111,11 +118,17 @@ fun GoldSettingContent(
                 .padding(paddingValues)
         ) {
             item {
-                CharacterDetailSimpleUI(
-                    character = character,
-                    onReloadClick = { viewModel.onReloadClick(context, character?.name) },
-                    onAvatarClick = { viewModel.onAvatarClick(character) }
-                )
+                AnimatedVisibility(
+                    visible = showDetail,
+                    enter = expandVertically(animationSpec = tween(100, easing = LinearEasing)),
+                    exit = shrinkVertically(animationSpec = tween(100, easing = LinearEasing))
+                ) {
+                    CharacterDetailSimpleUI(
+                        character = character,
+                        onReloadClick = { viewModel.onReloadClick(context, character?.name) },
+                        onAvatarClick = { viewModel.onAvatarClick(character) }
+                    )
+                }
             }
             stickyHeader { RaidHeader(viewModel) }
             item { GoldSetting(viewModel, cbVM, adVM, kzVM, epVM) }
@@ -140,7 +153,7 @@ fun CharacterDetailSimpleUI(
     character: Character? = null,
     onReloadClick: () -> Unit = {},
     onAvatarClick: () -> Unit = {},
-    onGetClick:() -> Unit = {},
+    onGetClick: () -> Unit = {},
     getButtonEnabled: Boolean = false
 ) {
     character?.let {
@@ -251,7 +264,8 @@ private fun LoadAPIDataCharInfo(
             .fillMaxWidth()
             .height(height)
     ) {
-        val characterImage = if (it.characterImage.isNullOrEmpty()) CharacterResourceMapper.getClassDefaultImg(it.characterClassName) else it.characterImage
+        val characterImage =
+            if (it.characterImage.isNullOrEmpty()) CharacterResourceMapper.getClassDefaultImg(it.characterClassName) else it.characterImage
 
         GlideImage(
             modifier = Modifier

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -90,6 +91,7 @@ import kotlinx.coroutines.launch
 fun GoldSettingContent(
     paddingValues: PaddingValues,
     viewModel: GoldSettingVM,
+    scrollState: LazyListState,
     cbVM: CommandBossVM,
     adVM: AbyssDungeonVM,
     kzVM: KazerothRaidVM,
@@ -106,7 +108,8 @@ fun GoldSettingContent(
     } else {
         LazyColumn(
             modifier = Modifier
-                .padding(paddingValues)
+                .padding(paddingValues),
+            state = scrollState
         ) {
             item {
                 AnimatedVisibility(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -40,8 +41,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -51,6 +54,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -76,6 +80,7 @@ import com.hongmyeoun.goldcalc.view.characterDetail.ItemLevel
 import com.hongmyeoun.goldcalc.view.characterDetail.Levels
 import com.hongmyeoun.goldcalc.view.characterDetail.ServerClassName
 import com.hongmyeoun.goldcalc.view.characterDetail.TitleCharName
+import com.hongmyeoun.goldcalc.view.characterDetail.normalTextStyle
 import com.hongmyeoun.goldcalc.view.goldCheck.RaidCard
 import com.hongmyeoun.goldcalc.view.goldCheck.cardContent.AbyssDungeon
 import com.hongmyeoun.goldcalc.view.goldCheck.cardContent.CommandRaid
@@ -323,73 +328,48 @@ fun BlinkingText(isBlinking: Boolean, text: String, modifier: Modifier) {
 }
 
 @Composable
-private fun RaidHeader(viewModel: GoldSettingVM, isDark: Boolean = isSystemInDarkTheme()) {
-    val bgColor = if (isDark) ImageBG else Color.White
-    Column {
-        Divider()
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(bgColor)
-                .height(50.dp)
-        ) {
-            TopBarBox(
-                title = "군단장",
-                modifier = Modifier.weight(1f),
-                selectedHeader = viewModel.selectedTab,
-                onClick = { viewModel.moveCommandRaid() }
-            )
-            Divider(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .width(1.dp)
-            )
+private fun RaidHeader(viewModel: GoldSettingVM) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(LightGrayBG)
+            .height(50.dp)
+    ) {
+        TopBarBox(
+            title = "군단장",
+            modifier = Modifier.weight(1f),
+            selectedHeader = viewModel.selectedTab,
+            onClick = { viewModel.moveCommandRaid() }
+        )
 
-            TopBarBox(
-                title = "어비스 던전",
-                modifier = Modifier.weight(1f),
-                onClick = { viewModel.moveAbyssDungeon() },
-                selectedHeader = viewModel.selectedTab
-            )
-            Divider(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .width(1.dp)
-            )
+        TopBarBox(
+            title = "어비스 던전",
+            modifier = Modifier.weight(1f),
+            onClick = { viewModel.moveAbyssDungeon() },
+            selectedHeader = viewModel.selectedTab
+        )
 
-            TopBarBox(
-                title = "카제로스",
-                modifier = Modifier.weight(1f),
-                onClick = { viewModel.moveKazeRaid() },
-                selectedHeader = viewModel.selectedTab
-            )
-            Divider(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .width(1.dp)
-            )
+        TopBarBox(
+            title = "카제로스",
+            modifier = Modifier.weight(1f),
+            onClick = { viewModel.moveKazeRaid() },
+            selectedHeader = viewModel.selectedTab
+        )
 
-            TopBarBox(
-                title = "에픽",
-                modifier = Modifier.weight(1f),
-                onClick = { viewModel.moveEpicRaid() },
-                selectedHeader = viewModel.selectedTab
-            )
-            Divider(
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .width(1.dp)
-            )
+        TopBarBox(
+            title = "에픽",
+            modifier = Modifier.weight(1f),
+            onClick = { viewModel.moveEpicRaid() },
+            selectedHeader = viewModel.selectedTab
+        )
 
-            TopBarBox(
-                title = "기타",
-                modifier = Modifier.weight(1f),
-                onClick = { viewModel.moveETC() },
-                selectedHeader = viewModel.selectedTab
-            )
-        }
+        TopBarBox(
+            title = "기타",
+            modifier = Modifier.weight(1f),
+            onClick = { viewModel.moveETC() },
+            selectedHeader = viewModel.selectedTab
+        )
     }
-    Divider()
 }
 
 @Composable
@@ -399,26 +379,25 @@ private fun TopBarBox(
     onClick: () -> Unit,
     selectedHeader: String
 ) {
-    val selectedBGColor = if (selectedHeader == title) Color.White else ImageBG
-    val selectedTextColor = if (selectedHeader == title) Color.Black else Color.White
+    val selectedBGColor = if (selectedHeader != title) LightGrayBG else ImageBG
 
     Box(
         modifier = modifier
             .fillMaxSize()
             .clickable { onClick() }
-            .background(selectedBGColor),
+            .background(selectedBGColor, RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
+            .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
         contentAlignment = Alignment.Center
     ) {
         if (title == "어비스 던전") {
             Text(
                 text = title,
-                fontSize = 12.sp,
-                color = selectedTextColor
+                style = normalTextStyle(fontSize = 12.sp)
             )
         } else {
             Text(
                 text = title,
-                color = selectedTextColor
+                color = Color.White
             )
         }
     }
@@ -513,6 +492,16 @@ fun ETCGold(
                     keyboardController?.hide()
                     focusState.clearFocus()
                 }
+            ),
+            colors = OutlinedTextFieldDefaults.colors(
+                unfocusedBorderColor = Color.White,
+                focusedBorderColor = Color.White,
+
+                unfocusedLabelColor = Color.White,
+                focusedLabelColor = Color.White,
+
+                unfocusedTextColor = Color.White,
+                focusedTextColor = Color.White
             )
         )
 
@@ -532,6 +521,16 @@ fun ETCGold(
                     keyboardController?.hide()
                     focusState.clearFocus()
                 }
+            ),
+            colors = OutlinedTextFieldDefaults.colors(
+                unfocusedBorderColor = Color.White,
+                focusedBorderColor = Color.White,
+
+                unfocusedLabelColor = Color.White,
+                focusedLabelColor = Color.White,
+
+                unfocusedTextColor = Color.White,
+                focusedTextColor = Color.White
             )
         )
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -61,7 +60,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
@@ -71,8 +69,8 @@ import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterDetail
 import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterResourceMapper
 import com.hongmyeoun.goldcalc.model.roomDB.character.Character
-import com.hongmyeoun.goldcalc.ui.theme.DarkModeGray
 import com.hongmyeoun.goldcalc.ui.theme.ImageBG
+import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.view.characterDetail.Extra
 import com.hongmyeoun.goldcalc.view.characterDetail.ItemLevel
 import com.hongmyeoun.goldcalc.view.characterDetail.Levels
@@ -184,7 +182,7 @@ private fun LoadLocalDataCharInfo(
             GlideImage(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .height(320.dp),
+                    .height(300.dp),
                 model = it.characterImage,
                 contentDescription = "캐릭터 이미지"
             )
@@ -192,7 +190,7 @@ private fun LoadLocalDataCharInfo(
             GlideImage(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .height(320.dp),
+                    .height(300.dp),
                 contentScale = ContentScale.FillHeight,
                 model = CharacterResourceMapper.getClassDefaultImg(it.className),
                 contentDescription = "캐릭터 이미지"
@@ -200,19 +198,13 @@ private fun LoadLocalDataCharInfo(
         }
         Column(
             modifier = Modifier
-                .align(Alignment.CenterStart)
-                .padding(start = 8.dp, top = 8.dp, bottom = 8.dp)
+                .padding(start = 16.dp, top = 24.dp)
         ) {
-            DetailInfomation(detailMenu = "닉네임", detail = it.name)
-            DetailInfomation(detailMenu = "서    버", detail = it.serverName)
-            DetailInfomation(detailMenu = "클래스", detail = it.className)
-            DetailInfomation(detailMenu = "템레벨", detail = it.itemLevel)
-            DetailInfomation(detailMenu = "원정대", detail = it.expeditionLevel.toString())
-            DetailInfomation(detailMenu = "칭    호", detail = it.title)
-            DetailInfomation(detailMenu = "전투렙", detail = it.characterLevel.toString())
-            DetailInfomation(detailMenu = "길    드", detail = it.guildName ?: "-")
-            DetailInfomation(detailMenu = "P  V  P", detail = it.pvpGradeName)
-            DetailInfomation(detailMenu = "영    지", detail = "Lv.${it.townLevel} ${it.townName}")
+            ServerClassName(serverName = it.serverName, className = it.className)
+            TitleCharName(title = it.title, name = it.name)
+            ItemLevel(level = it.itemLevel)
+            Extra(character = it)
+            Levels(character = it)
         }
         Column(
             modifier = Modifier
@@ -228,7 +220,7 @@ private fun LoadLocalDataCharInfo(
                         isBlinking = false
                     }
                 },
-                containerColor = DarkModeGray
+                containerColor = LightGrayBG
             ) {
                 Icon(
                     imageVector = Icons.Default.Person,
@@ -238,7 +230,7 @@ private fun LoadLocalDataCharInfo(
             }
             SmallFloatingActionButton(
                 onClick = onReloadClick,
-                containerColor = DarkModeGray
+                containerColor = LightGrayBG
             ) {
                 Icon(
                     imageVector = Icons.Default.Refresh,
@@ -329,27 +321,6 @@ fun BlinkingText(isBlinking: Boolean, text: String, modifier: Modifier) {
         }
     }
 }
-
-@Composable
-private fun DetailInfomation(detailMenu: String, detail: String) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            modifier = Modifier
-                .background(DarkModeGray, RoundedCornerShape(16.dp))
-                .width(80.dp),
-            text = "  $detailMenu  ",
-            color = Color.White,
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.width(10.dp))
-        Text(
-            text = detail,
-            color = Color.White
-        )
-    }
-    Spacer(modifier = Modifier.height(4.dp))
-}
-
 
 @Composable
 private fun RaidHeader(viewModel: GoldSettingVM, isDark: Boolean = isSystemInDarkTheme()) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,9 +30,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ElevatedButton
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SmallFloatingActionButton
@@ -50,7 +47,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -90,7 +86,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class)
 fun GoldSettingContent(
     paddingValues: PaddingValues,
     viewModel: GoldSettingVM,
@@ -102,9 +98,6 @@ fun GoldSettingContent(
     val character by viewModel.character.collectAsState()
     val context = LocalContext.current
     val isLoading by viewModel.isLoading.collectAsState()
-    val configuration = LocalConfiguration.current
-    val screenHeight = configuration.screenHeightDp.dp
-    val maxColumnHeight = (screenHeight * 0.93f) // 화면 높이의 80%
 
     val showDetail by viewModel.showDetail.collectAsState()
 
@@ -130,17 +123,6 @@ fun GoldSettingContent(
             }
             stickyHeader { RaidHeader(viewModel) }
             item { GoldSetting(viewModel, cbVM, adVM, kzVM, epVM) }
-        }
-    }
-
-
-    if (viewModel.expanded) {
-        ModalBottomSheet(
-            modifier = Modifier
-                .heightIn(max = maxColumnHeight),
-            onDismissRequest = { viewModel.close() },
-        ) {
-            SimpleSummary(cbVM, adVM, kzVM, epVM, viewModel)
         }
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingContent.kt
@@ -13,29 +13,23 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -44,7 +38,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -54,7 +47,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -68,6 +60,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
+import com.example.bottombar.AnimatedBottomBar
+import com.example.bottombar.model.IndicatorDirection
+import com.example.bottombar.model.IndicatorStyle
 import com.hongmyeoun.goldcalc.LoadingScreen
 import com.hongmyeoun.goldcalc.R
 import com.hongmyeoun.goldcalc.model.lostArkApi.CharacterDetail
@@ -329,46 +324,23 @@ fun BlinkingText(isBlinking: Boolean, text: String, modifier: Modifier) {
 
 @Composable
 private fun RaidHeader(viewModel: GoldSettingVM) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(LightGrayBG)
-            .height(50.dp)
+    AnimatedBottomBar(
+        modifier = Modifier.fillMaxWidth(),
+        bottomBarHeight = 50.dp,
+        containerColor = LightGrayBG,
+        selectedItem = viewModel.selectedTab,
+        itemSize = viewModel.headerTitle.size,
+        indicatorColor = Color.LightGray,
+        indicatorStyle = IndicatorStyle.LINE,
+        indicatorDirection = IndicatorDirection.BOTTOM
     ) {
-        TopBarBox(
-            title = "군단장",
-            modifier = Modifier.weight(1f),
-            selectedHeader = viewModel.selectedTab,
-            onClick = { viewModel.moveCommandRaid() }
-        )
-
-        TopBarBox(
-            title = "어비스 던전",
-            modifier = Modifier.weight(1f),
-            onClick = { viewModel.moveAbyssDungeon() },
-            selectedHeader = viewModel.selectedTab
-        )
-
-        TopBarBox(
-            title = "카제로스",
-            modifier = Modifier.weight(1f),
-            onClick = { viewModel.moveKazeRaid() },
-            selectedHeader = viewModel.selectedTab
-        )
-
-        TopBarBox(
-            title = "에픽",
-            modifier = Modifier.weight(1f),
-            onClick = { viewModel.moveEpicRaid() },
-            selectedHeader = viewModel.selectedTab
-        )
-
-        TopBarBox(
-            title = "기타",
-            modifier = Modifier.weight(1f),
-            onClick = { viewModel.moveETC() },
-            selectedHeader = viewModel.selectedTab
-        )
+        viewModel.headerTitle.forEachIndexed { index, title ->
+            TopBarBox(
+                title = title,
+                modifier = Modifier.weight(1f),
+                onClick = { viewModel.moveHeader(index) }
+            )
+        }
     }
 }
 
@@ -377,16 +349,12 @@ private fun TopBarBox(
     title: String,
     modifier: Modifier,
     onClick: () -> Unit,
-    selectedHeader: String
 ) {
-    val selectedBGColor = if (selectedHeader != title) LightGrayBG else ImageBG
-
     Box(
         modifier = modifier
             .fillMaxSize()
             .clickable { onClick() }
-            .background(selectedBGColor, RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
-            .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+        ,
         contentAlignment = Alignment.Center
     ) {
         if (title == "어비스 던전") {
@@ -417,7 +385,7 @@ private fun GoldSetting(
             .fillMaxSize()
     ) {
         when (viewModel.selectedTab) {
-            "군단장" -> {
+            0 -> {
                 RaidCard(
                     raidImg = R.drawable.command_icon,
                     totalGold = cbVM.totalGold
@@ -426,7 +394,7 @@ private fun GoldSetting(
                 }
             }
 
-            "어비스 던전" -> {
+            1 -> {
                 RaidCard(
                     raidImg = R.drawable.abyss_dungeon_icon,
                     totalGold = adVM.totalGold,
@@ -435,7 +403,7 @@ private fun GoldSetting(
                 }
             }
 
-            "카제로스" -> {
+            2 -> {
                 RaidCard(
                     raidImg = R.drawable.kazeroth_icon,
                     totalGold = kzVM.totalGold
@@ -444,7 +412,7 @@ private fun GoldSetting(
                 }
             }
 
-            "에픽" -> {
+            3 -> {
                 RaidCard(
                     raidImg = R.drawable.epic_icon,
                     totalGold = epVM.totalGold
@@ -453,7 +421,7 @@ private fun GoldSetting(
                 }
             }
 
-            "기타" -> {
+            4 -> {
                 ETCGold(
                     viewModel = viewModel,
                     onDone = { viewModel.updateTotalGold(cbVM.totalGold, adVM.totalGold, kzVM.totalGold, epVM.totalGold) },

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingTopBar.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingTopBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -22,6 +23,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,14 +39,18 @@ import com.hongmyeoun.goldcalc.ui.theme.LightBlue
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.view.characterDetail.titleTextStyle
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.GoldSettingVM
+import kotlinx.coroutines.launch
 
 @Composable
 fun GoldSettingTopBar(
     viewModel: GoldSettingVM,
-    navController: NavHostController
+    navController: NavHostController,
+    scrollState: LazyListState
 ) {
     val showDialog by viewModel.showDialog.collectAsState()
     val showDetail by viewModel.showDetail.collectAsState()
+
+    val scope = rememberCoroutineScope()
 
     if (showDialog) {
         DeleteCharacterDialog(viewModel, navController)
@@ -59,7 +65,12 @@ fun GoldSettingTopBar(
         ) {
             IconButton(
                 modifier = Modifier.weight(0.5f),
-                onClick = { viewModel.onShowDetailClicked() }
+                onClick = {
+                    viewModel.onShowDetailClicked()
+                    scope.launch {
+                        scrollState.animateScrollToItem(0)
+                    }
+                }
             ) {
                 if (showDetail) {
                     Icon(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingTopBar.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingTopBar.kt
@@ -12,7 +12,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -38,27 +39,41 @@ import com.hongmyeoun.goldcalc.view.characterDetail.titleTextStyle
 import com.hongmyeoun.goldcalc.viewModel.goldCheck.GoldSettingVM
 
 @Composable
-fun GoldSettingTopBar(viewModel: GoldSettingVM, navController: NavHostController) {
+fun GoldSettingTopBar(
+    viewModel: GoldSettingVM,
+    navController: NavHostController
+) {
     val showDialog by viewModel.showDialog.collectAsState()
+    val showDetail by viewModel.showDetail.collectAsState()
 
     if (showDialog) {
         DeleteCharacterDialog(viewModel, navController)
     }
 
-    Column(modifier = Modifier.background(LightGrayBG)) {
+    Column(
+        modifier = Modifier.background(LightGrayBG)
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(
                 modifier = Modifier.weight(0.5f),
-                onClick = { navController.popBackStack() }
+                onClick = { viewModel.onShowDetailClicked() }
             ) {
-                Icon(
-                    imageVector = Icons.Default.KeyboardArrowLeft,
-                    tint = Color.White,
-                    contentDescription = "뒤로"
-                )
+                if (showDetail) {
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowUp,
+                        tint = Color.White,
+                        contentDescription = "펼치기"
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowDown,
+                        tint = Color.White,
+                        contentDescription = "접기"
+                    )
+                }
             }
             Text(
                 modifier = Modifier

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingTopBar.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/goldCheck/setting/GoldSettingTopBar.kt
@@ -94,7 +94,6 @@ fun GoldSettingTopBar(
                 )
             }
         }
-        Divider()
     }
 }
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/main/MainTopBar.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/main/MainTopBar.kt
@@ -541,8 +541,8 @@ fun Float.toPercentage(): String {
 
 fun goldImage(gold: Int): Int {
     return when (gold) {
-        in 0 until 5000 -> R.drawable.gold_coins
-        in 5000 until 20000 -> R.drawable.gold_bar
+        in 0 until 10000 -> R.drawable.gold_coins
+        in 10000 until 20000 -> R.drawable.gold_bar
         in 20000 until 50000 -> R.drawable.gold_box
         else -> R.drawable.gold_bar_many
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/main/MainView.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/main/MainView.kt
@@ -3,6 +3,7 @@ package com.hongmyeoun.goldcalc.view.main
 import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -13,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
 import com.hongmyeoun.goldcalc.viewModel.main.CharacterListVM
@@ -31,7 +33,8 @@ fun MainScreen(
 
     Scaffold(
         topBar = { MainAppTopBar(navController, characterListVM) },
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        contentWindowInsets = WindowInsets(0.dp)
     ) {
         content(
             Modifier

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/goldCheck/GoldSettingVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/goldCheck/GoldSettingVM.kt
@@ -119,25 +119,10 @@ class GoldSettingVM @Inject constructor(
         expanded = false
     }
 
-    var selectedTab by mutableStateOf("군단장")
-    fun moveCommandRaid() {
-        selectedTab = "군단장"
-    }
-
-    fun moveAbyssDungeon() {
-        selectedTab = "어비스 던전"
-    }
-
-    fun moveKazeRaid() {
-        selectedTab = "카제로스"
-    }
-
-    fun moveEpicRaid() {
-        selectedTab = "에픽"
-    }
-
-    fun moveETC() {
-        selectedTab = "기타"
+    val headerTitle = listOf("군단장", "어비스 던전", "카제로스", "에픽", "기타")
+    var selectedTab by mutableStateOf(0)
+    fun moveHeader(index: Int) {
+        selectedTab = index
     }
 
     private fun updateCharacterDetail(characterDetail: CharacterDetail) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/goldCheck/GoldSettingVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/goldCheck/GoldSettingVM.kt
@@ -33,6 +33,13 @@ class GoldSettingVM @Inject constructor(
         _showDialog.value = true
     }
 
+    private val _showDetail = MutableStateFlow(false)
+    val showDetail: StateFlow<Boolean> = _showDetail
+
+    fun onShowDetailClicked() {
+        _showDetail.value = !_showDetail.value
+    }
+
     var plusGold by mutableStateOf("0")
     var minusGold by mutableStateOf("0")
 


### PR DESCRIPTION
# GoldCheck UI 색 통일
기존 Dark, White 모드를 고려해서 만든 색감을 항상 어둡게 변경
그 외에도 여러 UI 개선

## 캐릭터 상세
|변경전|변경후|
|:---|:---|
|![캐릭상세전](https://github.com/hongmyeoun/GoldCalc/assets/139526068/b4171338-22b3-41b6-86d2-d0ccbbb1adc6)<br>- 닫을 수 없는 무조건 표기되는 UI|![캐릭터상세](https://github.com/hongmyeoun/GoldCalc/assets/139526068/36760414-2112-46a8-983e-056fbe84108a)<br>- 닫고 열 수 있는 UI<br>- 열고 닫을때 애니메이션 추가|

## Header
|변경전|변경후|
|:---|:---|
|![헤더전](https://github.com/hongmyeoun/GoldCalc/assets/139526068/eba97291-0394-4948-8563-c694c73061ca)<br>- 그냥 탭하면 이동하는 UI|![헤더](https://github.com/hongmyeoun/GoldCalc/assets/139526068/d6666f47-51c9-44ab-b431-c827949b67f8)<br>- 탭할시 애니메이션으로 현재 어느 탭인지 명확히 확인|

## 하단바
|변경전|변경후|
|:---|:---|
|![바텀바전](https://github.com/hongmyeoun/GoldCalc/assets/139526068/77c6a76a-d7e5-41e2-9b26-c27e2cf1f0a9)<br>- 탭하면 bottomSheet가 올라옴<br>- navigationBar와 분리가 안됨|![바텀바](https://github.com/hongmyeoun/GoldCalc/assets/139526068/6a22c1cb-dd84-4437-b4af-354d429a422d)<br>- 위로 드래그시 bottomSheet가 올라옴<br>- 스크롤시 navigationBar가 나옴|

## RaidCard 색 통일
|변경전|변경후|
|:---:|:---:|
|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/f84cf84a-32e8-4dfc-9216-aa878c58655f)|![image](https://github.com/hongmyeoun/GoldCalc/assets/139526068/2d7a6e19-87ca-41d3-8c98-ed003f9373b8)|

