### PR TITLE
Season 3 gold nerf

### DIFF
--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/AbyssDungeon.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/AbyssDungeon.kt
@@ -12,12 +12,12 @@ enum class AbyssDungeon(
         seeMoreGold = mapOf(
             "normal" to listOf(300, 400, 500),
             "hard" to listOf(350, 500, 700),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(0, 0, 0)
         ),
         clearGold = mapOf(
             "normal" to listOf(800, 1200, 1600),
             "hard" to listOf(1000, 1600, 2200),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(250, 400, 550)
         )
     ),
     IVORY_TOWER(
@@ -25,12 +25,12 @@ enum class AbyssDungeon(
         seeMoreGold = mapOf(
             "normal" to listOf(600, 650, 1000),
             "hard" to listOf(1200, 1450, 2000),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(0, 0, 0)
         ),
         clearGold = mapOf(
             "normal" to listOf(1500, 2000, 3000),
             "hard" to listOf(3000, 4000, 6000),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(450, 675, 1000)
         )
     );
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/AbyssDungeon.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/AbyssDungeon.kt
@@ -10,23 +10,23 @@ enum class AbyssDungeon(
     KAYANGEL(
         boss = "카양겔",
         seeMoreGold = mapOf(
-            "normal" to listOf(600, 800, 1000),
-            "hard" to listOf(700, 900, 1100)
+            "normal" to listOf(300, 400, 500),
+            "hard" to listOf(350, 500, 700)
         ),
         clearGold = mapOf(
-            "normal" to listOf(1000, 1500, 2000),
-            "hard" to listOf(1500, 2000, 3000)
+            "normal" to listOf(800, 1200, 1600),
+            "hard" to listOf(1000, 1600, 2200)
         )
     ),
     IVORY_TOWER(
         boss = "상아탑",
         seeMoreGold = mapOf(
-            "normal" to listOf(700, 800, 900, 1100),
-            "hard" to listOf(1000, 1000, 1500, 2000)
+            "normal" to listOf(600, 650, 1000),
+            "hard" to listOf(1200, 1450, 2000)
         ),
         clearGold = mapOf(
-            "normal" to listOf(1500, 1750, 2500, 3250),
-            "hard" to listOf(2000, 2500, 4000, 6000)
+            "normal" to listOf(1500, 2000, 3000),
+            "hard" to listOf(3000, 4000, 6000)
         )
     );
 
@@ -141,9 +141,9 @@ class IvoryTower(character: Character?) {
         moreCheck = onePhaseMCheck,
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[0],
-        seeMoreGoldH = seeMoreGold[4],
+        seeMoreGoldH = seeMoreGold[3],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[4]
+        clearGoldH = clearGold[3]
     )
 
     private val getTwoPhase = character?.checkList?.abyssDungeon?.get(1)?.phases?.get(1)
@@ -158,9 +158,9 @@ class IvoryTower(character: Character?) {
         moreCheck = twoPhaseMCheck,
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[1],
-        seeMoreGoldH = seeMoreGold[5],
+        seeMoreGoldH = seeMoreGold[4],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[5]
+        clearGoldH = clearGold[4]
     )
 
     private val getThreePhase = character?.checkList?.abyssDungeon?.get(1)?.phases?.get(2)
@@ -174,38 +174,21 @@ class IvoryTower(character: Character?) {
         moreCheck = threePhaseMCheck,
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[2],
-        seeMoreGoldH = seeMoreGold[6],
+        seeMoreGoldH = seeMoreGold[5],
         clearGoldN = clearGold[2],
-        clearGoldH = clearGold[6]
+        clearGoldH = clearGold[5]
     )
 
-    private val getFourPhase = character?.checkList?.abyssDungeon?.get(1)?.phases?.get(3)
-    private val fourPhaseDifficulty = getFourPhase?.difficulty?:"노말"
-    private val fourPhaseIsClear = getFourPhase?.isClear?:false
-    private val fourPhaseMCheck = getFourPhase?.mCheck?:false
-
-    val fourPhase = PhaseInfo(
-        difficulty = fourPhaseDifficulty,
-        isClearCheck = fourPhaseIsClear,
-        moreCheck = fourPhaseMCheck,
-        isChecked = isChecked,
-        seeMoreGoldN = seeMoreGold[3],
-        seeMoreGoldH = seeMoreGold[7],
-        clearGoldN = clearGold[3],
-        clearGoldH = clearGold[7]
-    )
-
-    var totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold + fourPhase.totalGold
+    var totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold
 
     fun totalGold() {
-        totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold + fourPhase.totalGold
+        totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold
     }
 
     fun onShowChecked() {
         onePhase.onShowChecked()
         twoPhase.onShowChecked()
         threePhase.onShowChecked()
-        fourPhase.onShowChecked()
     }
 
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/AbyssDungeon.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/AbyssDungeon.kt
@@ -11,22 +11,26 @@ enum class AbyssDungeon(
         boss = "카양겔",
         seeMoreGold = mapOf(
             "normal" to listOf(300, 400, 500),
-            "hard" to listOf(350, 500, 700)
+            "hard" to listOf(350, 500, 700),
+            "solo" to listOf(1, 2, 3)
         ),
         clearGold = mapOf(
             "normal" to listOf(800, 1200, 1600),
-            "hard" to listOf(1000, 1600, 2200)
+            "hard" to listOf(1000, 1600, 2200),
+            "solo" to listOf(1, 2, 3)
         )
     ),
     IVORY_TOWER(
         boss = "상아탑",
         seeMoreGold = mapOf(
             "normal" to listOf(600, 650, 1000),
-            "hard" to listOf(1200, 1450, 2000)
+            "hard" to listOf(1200, 1450, 2000),
+            "solo" to listOf(1, 2, 3)
         ),
         clearGold = mapOf(
             "normal" to listOf(1500, 2000, 3000),
-            "hard" to listOf(3000, 4000, 6000)
+            "hard" to listOf(3000, 4000, 6000),
+            "solo" to listOf(1, 2, 3)
         )
     );
 
@@ -53,8 +57,8 @@ class AbyssDungeonModel(character: Character?) {
 
 class Kayangel(character: Character?) {
     val name = AbyssDungeon.KAYANGEL.boss
-    private val seeMoreGold = AbyssDungeon.KAYANGEL.getBossInfo("normal").first + AbyssDungeon.KAYANGEL.getBossInfo("hard").first
-    private val clearGold = AbyssDungeon.KAYANGEL.getBossInfo("normal").second + AbyssDungeon.KAYANGEL.getBossInfo("hard").second
+    private val seeMoreGold = AbyssDungeon.KAYANGEL.getBossInfo("normal").first + AbyssDungeon.KAYANGEL.getBossInfo("hard").first + AbyssDungeon.KAYANGEL.getBossInfo("solo").first
+    private val clearGold = AbyssDungeon.KAYANGEL.getBossInfo("normal").second + AbyssDungeon.KAYANGEL.getBossInfo("hard").second + AbyssDungeon.KAYANGEL.getBossInfo("solo").second
 
     var isChecked = character?.checkList?.abyssDungeon?.get(0)?.isCheck?:false
 
@@ -71,8 +75,10 @@ class Kayangel(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[0],
         seeMoreGoldH = seeMoreGold[3],
+        seeMoreGoldS = seeMoreGold[6],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[3]
+        clearGoldH = clearGold[3],
+        clearGoldS = clearGold[6]
     )
 
     private val getTwoPhase = character?.checkList?.abyssDungeon?.get(0)?.phases?.get(1)
@@ -88,8 +94,10 @@ class Kayangel(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[1],
         seeMoreGoldH = seeMoreGold[4],
+        seeMoreGoldS = seeMoreGold[7],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[4]
+        clearGoldH = clearGold[4],
+        clearGoldS = clearGold[7]
     )
 
     private val getThreePhase = character?.checkList?.abyssDungeon?.get(0)?.phases?.get(2)
@@ -104,8 +112,10 @@ class Kayangel(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[2],
         seeMoreGoldH = seeMoreGold[5],
+        seeMoreGoldS = seeMoreGold[8],
         clearGoldN = clearGold[2],
-        clearGoldH = clearGold[5]
+        clearGoldH = clearGold[5],
+        clearGoldS = clearGold[8]
     )
 
     var totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold
@@ -119,13 +129,12 @@ class Kayangel(character: Character?) {
         twoPhase.onShowChecked()
         threePhase.onShowChecked()
     }
-
 }
 
 class IvoryTower(character: Character?) {
     val name = AbyssDungeon.IVORY_TOWER.boss
-    private val seeMoreGold = AbyssDungeon.IVORY_TOWER.getBossInfo("normal").first + AbyssDungeon.IVORY_TOWER.getBossInfo("hard").first
-    private val clearGold = AbyssDungeon.IVORY_TOWER.getBossInfo("normal").second + AbyssDungeon.IVORY_TOWER.getBossInfo("hard").second
+    private val seeMoreGold = AbyssDungeon.IVORY_TOWER.getBossInfo("normal").first + AbyssDungeon.IVORY_TOWER.getBossInfo("hard").first + AbyssDungeon.IVORY_TOWER.getBossInfo("solo").first
+    private val clearGold = AbyssDungeon.IVORY_TOWER.getBossInfo("normal").second + AbyssDungeon.IVORY_TOWER.getBossInfo("hard").second + AbyssDungeon.IVORY_TOWER.getBossInfo("solo").second
 
     var isChecked = character?.checkList?.abyssDungeon?.get(1)?.isCheck?:false
 
@@ -142,8 +151,10 @@ class IvoryTower(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[0],
         seeMoreGoldH = seeMoreGold[3],
+        seeMoreGoldS = seeMoreGold[6],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[3]
+        clearGoldH = clearGold[3],
+        clearGoldS = clearGold[6]
     )
 
     private val getTwoPhase = character?.checkList?.abyssDungeon?.get(1)?.phases?.get(1)
@@ -159,8 +170,10 @@ class IvoryTower(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[1],
         seeMoreGoldH = seeMoreGold[4],
+        seeMoreGoldS = seeMoreGold[7],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[4]
+        clearGoldH = clearGold[4],
+        clearGoldS = clearGold[7]
     )
 
     private val getThreePhase = character?.checkList?.abyssDungeon?.get(1)?.phases?.get(2)
@@ -175,8 +188,10 @@ class IvoryTower(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[2],
         seeMoreGoldH = seeMoreGold[5],
+        seeMoreGoldS = seeMoreGold[8],
         clearGoldN = clearGold[2],
-        clearGoldH = clearGold[5]
+        clearGoldH = clearGold[5],
+        clearGoldS = clearGold[8]
     )
 
     var totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold
@@ -190,5 +205,4 @@ class IvoryTower(character: Character?) {
         twoPhase.onShowChecked()
         threePhase.onShowChecked()
     }
-
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/CommandBoss.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/CommandBoss.kt
@@ -12,12 +12,12 @@ enum class CommandBoss(
         seeMoreGold = mapOf(
             "normal" to listOf(300, 400),
             "hard" to listOf(450, 600),
-            "solo" to listOf(1, 2)
+            "solo" to listOf(0, 0)
         ),
         clearGold = mapOf(
             "normal" to listOf(500, 700),
             "hard" to listOf(700, 1100),
-            "solo" to listOf(1, 2)
+            "solo" to listOf(100, 150)
         )
     ),
     BIACKISS(
@@ -25,12 +25,12 @@ enum class CommandBoss(
         seeMoreGold = mapOf(
             "normal" to listOf(300, 450),
             "hard" to listOf(500, 650),
-            "solo" to listOf(1, 2)
+            "solo" to listOf(0, 0)
         ),
         clearGold = mapOf(
             "normal" to listOf(600, 1000),
             "hard" to listOf(900, 1500),
-            "solo" to listOf(1, 2)
+            "solo" to listOf(150, 275)
         )
     ),
     KOUKU_SATON(
@@ -38,12 +38,12 @@ enum class CommandBoss(
         seeMoreGold = mapOf(
             "normal" to listOf(300, 500, 600),
             "hard" to listOf(300, 500, 600),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(0, 0, 0)
         ),
         clearGold = mapOf(
             "normal" to listOf(600, 900, 1500),
             "hard" to listOf(600, 900, 1500),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(150, 200, 450)
         )
     ),
     ABRELSHUD(
@@ -51,12 +51,12 @@ enum class CommandBoss(
         seeMoreGold = mapOf(
             "normal" to listOf(250, 300, 400, 600),
             "hard" to listOf(400, 400, 500, 800),
-            "solo" to listOf(1, 2, 3, 4)
+            "solo" to listOf(0, 0, 0, 0)
         ),
         clearGold = mapOf(
             "normal" to listOf(1000, 1000, 1000, 1600),
             "hard" to listOf(1200, 1200, 1200, 2000),
-            "solo" to listOf(1, 2, 3, 4)
+            "solo" to listOf(375, 350, 300, 500)
         )
     ),
     ILLIAKAN(
@@ -64,12 +64,12 @@ enum class CommandBoss(
         seeMoreGold = mapOf(
             "normal" to listOf(450, 550, 750),
             "hard" to listOf(600, 700, 950),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(0, 0, 0)
         ),
         clearGold = mapOf(
             "normal" to listOf(1000, 1800, 2600),
             "hard" to listOf(1500, 2500, 3500),
-            "solo" to listOf(1, 2, 3)
+            "solo" to listOf(275, 575, 975)
         )
     ),
     KAMEN(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/CommandBoss.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/CommandBoss.kt
@@ -43,23 +43,23 @@ enum class CommandBoss(
     ABRELSHUD(
         boss = "아브렐슈드",
         seeMoreGold = mapOf(
-            "normal" to listOf(400, 600, 800, 1500),
-            "hard" to listOf(700, 900, 1100, 1800)
+            "normal" to listOf(250, 300, 400, 600),
+            "hard" to listOf(400, 400, 500, 800)
         ),
         clearGold = mapOf(
-            "normal" to listOf(1500, 1500, 1500, 2500),
-            "hard" to listOf(2000, 2000, 2000, 3000)
+            "normal" to listOf(1000, 1000, 1000, 1600),
+            "hard" to listOf(1200, 1200, 1200, 2000)
         )
     ),
     ILLIAKAN(
         boss = "일리아칸",
         seeMoreGold = mapOf(
-            "normal" to listOf(900, 1100, 1500),
-            "hard" to listOf(1200, 1400, 1900)
+            "normal" to listOf(450, 550, 750),
+            "hard" to listOf(600, 700, 950)
         ),
         clearGold = mapOf(
-            "normal" to listOf(1500, 2000, 4000),
-            "hard" to listOf(1750, 2500, 5750)
+            "normal" to listOf(1000, 1800, 2600),
+            "hard" to listOf(1500, 2500, 3500)
         )
     ),
     KAMEN(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/CommandBoss.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/CommandBoss.kt
@@ -11,55 +11,65 @@ enum class CommandBoss(
         boss = "발탄",
         seeMoreGold = mapOf(
             "normal" to listOf(300, 400),
-            "hard" to listOf(450, 600)
+            "hard" to listOf(450, 600),
+            "solo" to listOf(1, 2)
         ),
         clearGold = mapOf(
             "normal" to listOf(500, 700),
-            "hard" to listOf(700, 1100)
+            "hard" to listOf(700, 1100),
+            "solo" to listOf(1, 2)
         )
     ),
     BIACKISS(
         boss = "비아키스",
         seeMoreGold = mapOf(
             "normal" to listOf(300, 450),
-            "hard" to listOf(500, 650)
+            "hard" to listOf(500, 650),
+            "solo" to listOf(1, 2)
         ),
         clearGold = mapOf(
             "normal" to listOf(600, 1000),
-            "hard" to listOf(900, 1500)
+            "hard" to listOf(900, 1500),
+            "solo" to listOf(1, 2)
         )
     ),
     KOUKU_SATON(
         boss = "쿠크세이튼",
         seeMoreGold = mapOf(
             "normal" to listOf(300, 500, 600),
-            "hard" to listOf(300, 500, 600)
+            "hard" to listOf(300, 500, 600),
+            "solo" to listOf(1, 2, 3)
         ),
         clearGold = mapOf(
             "normal" to listOf(600, 900, 1500),
-            "hard" to listOf(600, 900, 1500)
+            "hard" to listOf(600, 900, 1500),
+            "solo" to listOf(1, 2, 3)
         )
     ),
     ABRELSHUD(
         boss = "아브렐슈드",
         seeMoreGold = mapOf(
             "normal" to listOf(250, 300, 400, 600),
-            "hard" to listOf(400, 400, 500, 800)
+            "hard" to listOf(400, 400, 500, 800),
+            "solo" to listOf(1, 2, 3, 4)
         ),
         clearGold = mapOf(
             "normal" to listOf(1000, 1000, 1000, 1600),
-            "hard" to listOf(1200, 1200, 1200, 2000)
+            "hard" to listOf(1200, 1200, 1200, 2000),
+            "solo" to listOf(1, 2, 3, 4)
         )
     ),
     ILLIAKAN(
         boss = "일리아칸",
         seeMoreGold = mapOf(
             "normal" to listOf(450, 550, 750),
-            "hard" to listOf(600, 700, 950)
+            "hard" to listOf(600, 700, 950),
+            "solo" to listOf(1, 2, 3)
         ),
         clearGold = mapOf(
             "normal" to listOf(1000, 1800, 2600),
-            "hard" to listOf(1500, 2500, 3500)
+            "hard" to listOf(1500, 2500, 3500),
+            "solo" to listOf(1, 2, 3)
         )
     ),
     KAMEN(
@@ -121,8 +131,8 @@ class CommandBossModel(character: Character?) {
 
 class Valtan(character: Character?) {
     var name = CommandBoss.VALTAN.boss
-    private val seeMoreGold = CommandBoss.VALTAN.getBossInfo("normal").first + CommandBoss.VALTAN.getBossInfo("hard").first
-    private val clearGold =  CommandBoss.VALTAN.getBossInfo("normal").second + CommandBoss.VALTAN.getBossInfo("hard").second
+    private val seeMoreGold = CommandBoss.VALTAN.getBossInfo("normal").first + CommandBoss.VALTAN.getBossInfo("hard").first + CommandBoss.VALTAN.getBossInfo("solo").first
+    private val clearGold =  CommandBoss.VALTAN.getBossInfo("normal").second + CommandBoss.VALTAN.getBossInfo("hard").second + CommandBoss.VALTAN.getBossInfo("solo").second
 
     var isChecked = character?.checkList?.command?.get(0)?.isCheck?:false
 
@@ -139,8 +149,10 @@ class Valtan(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[0],
         seeMoreGoldH = seeMoreGold[2],
+        seeMoreGoldS = seeMoreGold[4],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[2]
+        clearGoldH = clearGold[2],
+        clearGoldS = clearGold[4]
     )
 
     private val getTwoPhase = character?.checkList?.command?.get(0)?.phases?.get(1)
@@ -156,8 +168,10 @@ class Valtan(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[1],
         seeMoreGoldH = seeMoreGold[3],
+        seeMoreGoldS = seeMoreGold[5],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[3]
+        clearGoldH = clearGold[3],
+        clearGoldS = seeMoreGold[5]
     )
 
     var totalGold = onePhase.totalGold + twoPhase.totalGold
@@ -170,13 +184,12 @@ class Valtan(character: Character?) {
         onePhase.onShowChecked()
         twoPhase.onShowChecked()
     }
-
 }
 
 class Biackiss(character: Character?) {
     var name = CommandBoss.BIACKISS.boss
-    private val seeMoreGold = CommandBoss.BIACKISS.getBossInfo("normal").first + CommandBoss.BIACKISS.getBossInfo("hard").first
-    private val clearGold = CommandBoss.BIACKISS.getBossInfo("normal").second + CommandBoss.BIACKISS.getBossInfo("hard").second
+    private val seeMoreGold = CommandBoss.BIACKISS.getBossInfo("normal").first + CommandBoss.BIACKISS.getBossInfo("hard").first + CommandBoss.BIACKISS.getBossInfo("solo").first
+    private val clearGold = CommandBoss.BIACKISS.getBossInfo("normal").second + CommandBoss.BIACKISS.getBossInfo("hard").second + CommandBoss.BIACKISS.getBossInfo("solo").second
 
     var isChecked = character?.checkList?.command?.get(1)?.isCheck?:false
 
@@ -193,8 +206,10 @@ class Biackiss(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[0],
         seeMoreGoldH = seeMoreGold[2],
+        seeMoreGoldS = seeMoreGold[4],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[2]
+        clearGoldH = clearGold[2],
+        clearGoldS = clearGold[4]
     )
 
     private val getTwoPhase = character?.checkList?.command?.get(1)?.phases?.get(1)
@@ -210,8 +225,10 @@ class Biackiss(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[1],
         seeMoreGoldH = seeMoreGold[3],
+        seeMoreGoldS = seeMoreGold[5],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[3]
+        clearGoldH = clearGold[3],
+        clearGoldS = seeMoreGold[5]
     )
 
     var totalGold = onePhase.totalGold + twoPhase.totalGold
@@ -224,13 +241,12 @@ class Biackiss(character: Character?) {
         onePhase.onShowChecked()
         twoPhase.onShowChecked()
     }
-
 }
 
 class KoukuSaton(character: Character?) {
     var name = CommandBoss.KOUKU_SATON.boss
-    private val seeMoreGold = CommandBoss.KOUKU_SATON.getBossInfo("normal").first + CommandBoss.KOUKU_SATON.getBossInfo("hard").first
-    private val clearGold = CommandBoss.KOUKU_SATON.getBossInfo("normal").second + CommandBoss.KOUKU_SATON.getBossInfo("hard").second
+    private val seeMoreGold = CommandBoss.KOUKU_SATON.getBossInfo("normal").first + CommandBoss.KOUKU_SATON.getBossInfo("hard").first + CommandBoss.KOUKU_SATON.getBossInfo("solo").first
+    private val clearGold = CommandBoss.KOUKU_SATON.getBossInfo("normal").second + CommandBoss.KOUKU_SATON.getBossInfo("hard").second + CommandBoss.KOUKU_SATON.getBossInfo("solo").second
 
     var isChecked = character?.checkList?.command?.get(2)?.isCheck?:false
 
@@ -245,10 +261,13 @@ class KoukuSaton(character: Character?) {
         isClearCheck = onePhaseIsClear,
         moreCheck = onePhaseMCheck,
         isChecked = isChecked,
+        noHardWithSolo = true,
         seeMoreGoldN = seeMoreGold[0],
         seeMoreGoldH = seeMoreGold[3],
+        seeMoreGoldS = seeMoreGold[6],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[3]
+        clearGoldH = clearGold[3],
+        clearGoldS = clearGold[6]
     )
 
     private val getTwoPhase = character?.checkList?.command?.get(2)?.phases?.get(1)
@@ -262,10 +281,13 @@ class KoukuSaton(character: Character?) {
         isClearCheck = twoPhaseIsClear,
         moreCheck = twoPhaseMCheck,
         isChecked = isChecked,
+        noHardWithSolo = true,
         seeMoreGoldN = seeMoreGold[1],
         seeMoreGoldH = seeMoreGold[4],
+        seeMoreGoldS = seeMoreGold[7],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[4]
+        clearGoldH = clearGold[4],
+        clearGoldS = clearGold[7]
     )
 
     private val getThreePhase = character?.checkList?.command?.get(2)?.phases?.get(2)
@@ -278,10 +300,13 @@ class KoukuSaton(character: Character?) {
         isClearCheck = threePhaseIsClear,
         moreCheck = threePhaseMCheck,
         isChecked = isChecked,
+        noHardWithSolo = true,
         seeMoreGoldN = seeMoreGold[2],
         seeMoreGoldH = seeMoreGold[5],
+        seeMoreGoldS = seeMoreGold[8],
         clearGoldN = clearGold[2],
-        clearGoldH = clearGold[5]
+        clearGoldH = clearGold[5],
+        clearGoldS = clearGold[8]
     )
 
     var totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold
@@ -299,8 +324,8 @@ class KoukuSaton(character: Character?) {
 
 class Abrelshud(character: Character?) {
     var name = CommandBoss.ABRELSHUD.boss
-    private val seeMoreGold = CommandBoss.ABRELSHUD.getBossInfo("normal").first + CommandBoss.ABRELSHUD.getBossInfo("hard").first
-    private val clearGold = CommandBoss.ABRELSHUD.getBossInfo("normal").second + CommandBoss.ABRELSHUD.getBossInfo("hard").second
+    private val seeMoreGold = CommandBoss.ABRELSHUD.getBossInfo("normal").first + CommandBoss.ABRELSHUD.getBossInfo("hard").first + CommandBoss.ABRELSHUD.getBossInfo("solo").first
+    private val clearGold = CommandBoss.ABRELSHUD.getBossInfo("normal").second + CommandBoss.ABRELSHUD.getBossInfo("hard").second + CommandBoss.ABRELSHUD.getBossInfo("solo").second
 
     var isChecked = character?.checkList?.command?.get(3)?.isCheck?:false
 
@@ -317,8 +342,10 @@ class Abrelshud(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[0],
         seeMoreGoldH = seeMoreGold[4],
+        seeMoreGoldS = seeMoreGold[8],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[4]
+        clearGoldH = clearGold[4],
+        clearGoldS = clearGold[8]
     )
 
     private val getTwoPhase = character?.checkList?.command?.get(3)?.phases?.get(1)
@@ -334,8 +361,10 @@ class Abrelshud(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[1],
         seeMoreGoldH = seeMoreGold[5],
+        seeMoreGoldS = seeMoreGold[9],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[5]
+        clearGoldH = clearGold[5],
+        clearGoldS = clearGold[9]
     )
 
     private val getThreePhase = character?.checkList?.command?.get(3)?.phases?.get(2)
@@ -350,8 +379,10 @@ class Abrelshud(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[2],
         seeMoreGoldH = seeMoreGold[6],
+        seeMoreGoldS = seeMoreGold[10],
         clearGoldN = clearGold[2],
-        clearGoldH = clearGold[6]
+        clearGoldH = clearGold[6],
+        clearGoldS = clearGold[10]
     )
 
     private val getFourPhase = character?.checkList?.command?.get(3)?.phases?.get(3)
@@ -366,8 +397,10 @@ class Abrelshud(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[3],
         seeMoreGoldH = seeMoreGold[7],
+        seeMoreGoldS = seeMoreGold[11],
         clearGoldN = clearGold[3],
-        clearGoldH = clearGold[7]
+        clearGoldH = clearGold[7],
+        clearGoldS = clearGold[11]
     )
 
     var totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold + fourPhase.totalGold
@@ -386,8 +419,8 @@ class Abrelshud(character: Character?) {
 
 class Illiakan(character: Character?) {
     var name = CommandBoss.ILLIAKAN.boss
-    private val seeMoreGold = CommandBoss.ILLIAKAN.getBossInfo("normal").first + CommandBoss.ILLIAKAN.getBossInfo("hard").first
-    private val clearGold = CommandBoss.ILLIAKAN.getBossInfo("normal").second + CommandBoss.ILLIAKAN.getBossInfo("hard").second
+    private val seeMoreGold = CommandBoss.ILLIAKAN.getBossInfo("normal").first + CommandBoss.ILLIAKAN.getBossInfo("hard").first + CommandBoss.ILLIAKAN.getBossInfo("solo").first
+    private val clearGold = CommandBoss.ILLIAKAN.getBossInfo("normal").second + CommandBoss.ILLIAKAN.getBossInfo("hard").second + CommandBoss.ILLIAKAN.getBossInfo("solo").second
 
     var isChecked = character?.checkList?.command?.get(4)?.isCheck?:false
 
@@ -404,8 +437,10 @@ class Illiakan(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[0],
         seeMoreGoldH = seeMoreGold[3],
+        seeMoreGoldS = seeMoreGold[6],
         clearGoldN = clearGold[0],
-        clearGoldH = clearGold[3]
+        clearGoldH = clearGold[3],
+        clearGoldS = clearGold[6]
     )
 
     private val getTwoPhase = character?.checkList?.command?.get(4)?.phases?.get(1)
@@ -421,8 +456,10 @@ class Illiakan(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[1],
         seeMoreGoldH = seeMoreGold[4],
+        seeMoreGoldS = seeMoreGold[7],
         clearGoldN = clearGold[1],
-        clearGoldH = clearGold[4]
+        clearGoldH = clearGold[4],
+        clearGoldS = clearGold[7]
     )
 
     private val getThreePhase = character?.checkList?.command?.get(4)?.phases?.get(2)
@@ -437,8 +474,10 @@ class Illiakan(character: Character?) {
         isChecked = isChecked,
         seeMoreGoldN = seeMoreGold[2],
         seeMoreGoldH = seeMoreGold[5],
+        seeMoreGoldS = seeMoreGold[8],
         clearGoldN = clearGold[2],
-        clearGoldH = clearGold[5]
+        clearGoldH = clearGold[5],
+        clearGoldS = clearGold[8]
     )
 
     var totalGold = onePhase.totalGold + twoPhase.totalGold + threePhase.totalGold

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/Common.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/homework/Common.kt
@@ -5,10 +5,13 @@ class PhaseInfo(
     isClearCheck: Boolean,
     moreCheck: Boolean,
     isChecked: Boolean,
+    private val noHardWithSolo: Boolean = false,
     private val seeMoreGoldN: Int,
     private val seeMoreGoldH: Int,
+    private val seeMoreGoldS: Int? = null,
     private val clearGoldN: Int,
-    private val clearGoldH: Int
+    private val clearGoldH: Int,
+    private val clearGoldS: Int? = null
 ) {
     var level = difficulty
     var seeMoreCheck = moreCheck
@@ -21,27 +24,27 @@ class PhaseInfo(
 
     init {
         // 객체가 생성될 때 초기값 설정
-        seeMoreGold = GoldCalcFunction.smgCalculator(seeMoreCheck, level, seeMoreGoldN, seeMoreGoldH)
-        clearGold = GoldCalcFunction.cgCalculator(clearCheck, level, clearGoldN, clearGoldH)
+        seeMoreGold = GoldCalcFunction.smgCalculator(seeMoreCheck, level, seeMoreGoldN, seeMoreGoldH, seeMoreGoldS)
+        clearGold = GoldCalcFunction.cgCalculator(clearCheck, level, clearGoldN, clearGoldH, clearGoldS)
         totalGold = GoldCalcFunction.totalCGCalculator(clearGold, seeMoreGold)
     }
 
     fun onLevelClicked() {
         levelClicked()
-        seeMoreGoldCalculate(seeMoreGoldN, seeMoreGoldH)
-        clearGoldCalculate(clearGoldN, clearGoldH)
+        seeMoreGoldCalculate(seeMoreGoldN, seeMoreGoldH, seeMoreGoldS)
+        clearGoldCalculate(clearGoldN, clearGoldH, clearGoldS)
         totalClearGoldCalculate()
     }
 
     fun onClearCheckBoxClicked(phaseChecked: Boolean) {
         updateClearCheck(phaseChecked)
-        clearGoldCalculate(clearGoldN, clearGoldH)
+        clearGoldCalculate(clearGoldN, clearGoldH, clearGoldS)
         totalClearGoldCalculate()
     }
 
     fun onSeeMoreCheckBoxClicked(phaseChecked: Boolean) {
         updateSeeMoreCheck(phaseChecked)
-        seeMoreGoldCalculate(seeMoreGoldN, seeMoreGoldH)
+        seeMoreGoldCalculate(seeMoreGoldN, seeMoreGoldH, seeMoreGoldS)
         totalClearGoldCalculate()
     }
 
@@ -50,22 +53,22 @@ class PhaseInfo(
         if (!showCheck) {
             clearCheck = false
             seeMoreCheck = false
-            seeMoreGoldCalculate(seeMoreGoldN, seeMoreGoldH)
-            clearGoldCalculate(clearGoldN, clearGoldH)
+            seeMoreGoldCalculate(seeMoreGoldN, seeMoreGoldH, seeMoreGoldS)
+            clearGoldCalculate(clearGoldN, clearGoldH, clearGoldS)
             totalClearGoldCalculate()
         }
     }
 
     private fun levelClicked() {
-        level = GoldCalcFunction.levelDetector(level)
+        level = GoldCalcFunction.levelDetector(level, noHardWithSolo)
     }
 
-    private fun seeMoreGoldCalculate(seeMoreGoldN: Int, seeMoreGoldH: Int) {
-        seeMoreGold = GoldCalcFunction.smgCalculator(seeMoreCheck, level, seeMoreGoldN, seeMoreGoldH)
+    private fun seeMoreGoldCalculate(seeMoreGoldN: Int, seeMoreGoldH: Int, seeMoreGoldS: Int?) {
+        seeMoreGold = GoldCalcFunction.smgCalculator(seeMoreCheck, level, seeMoreGoldN, seeMoreGoldH, seeMoreGoldS)
     }
 
-    private fun clearGoldCalculate(clearGoldN: Int, clearGoldH: Int) {
-        clearGold = GoldCalcFunction.cgCalculator(clearCheck, level, clearGoldN, clearGoldH)
+    private fun clearGoldCalculate(clearGoldN: Int, clearGoldH: Int, clearGoldS: Int?) {
+        clearGold = GoldCalcFunction.cgCalculator(clearCheck, level, clearGoldN, clearGoldH, clearGoldS)
     }
 
     private fun totalClearGoldCalculate() {
@@ -82,16 +85,34 @@ class PhaseInfo(
 }
 
 object GoldCalcFunction {
-    fun levelDetector(level: String): String {
-        return if (level == "노말") "하드" else "노말"
+    fun levelDetector(level: String, noHardWithSolo: Boolean): String {
+        return if (noHardWithSolo) {
+            if (level == "노말") {
+                "솔로잉"
+            } else {
+                "노말"
+            }
+        } else {
+            when (level) {
+                "노말" -> {
+                    "하드"
+                }
+                "하드" -> {
+                    "솔로잉"
+                }
+                else -> {
+                    "노말"
+                }
+            }
+        }
     }
 
-    fun smgCalculator(isChecked: Boolean, level: String, seeMoreGoldN: Int, seeMoreGoldH: Int): Int {
-        return if (isChecked && level == "노말") seeMoreGoldN else if (isChecked && level == "하드") seeMoreGoldH else 0
+    fun smgCalculator(isChecked: Boolean, level: String, seeMoreGoldN: Int, seeMoreGoldH: Int, seeMoreGoldS: Int?): Int {
+        return if (isChecked && level == "노말") seeMoreGoldN else if (isChecked && level == "하드") seeMoreGoldH else if (isChecked && seeMoreGoldS != null && level == "솔로잉") seeMoreGoldS else 0
     }
 
-    fun cgCalculator(isChecked: Boolean, level: String, clearGoldN: Int, clearGoldH: Int): Int {
-        return if (isChecked && level == "노말") clearGoldN else if (isChecked) clearGoldH else 0
+    fun cgCalculator(isChecked: Boolean, level: String, clearGoldN: Int, clearGoldH: Int, clearGoldS: Int?): Int {
+        return if (isChecked && level == "노말") clearGoldN else if (isChecked && level == "하드") clearGoldH else if (isChecked && clearGoldS != null && level == "솔로잉") clearGoldS else 0
     }
 
     fun totalCGCalculator(cg: Int, smg: Int): Int {
@@ -101,5 +122,4 @@ object GoldCalcFunction {
     fun phaseChecked(phaseCheck: Boolean): Boolean {
         return phaseCheck
     }
-
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/roomDB/character/Character.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/roomDB/character/Character.kt
@@ -98,7 +98,7 @@ data class CheckList(
         ),
         RaidList(
             name = "상아탑",
-            phases = listOf(Phase(), Phase(), Phase(), Phase())
+            phases = listOf(Phase(), Phase(), Phase())
         ),
     ),
     @ColumnInfo("Kazeroth") val kazeroth: List<RaidList> = listOf(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/bottomBar/Summary.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/bottomBar/Summary.kt
@@ -270,14 +270,9 @@ private fun Script(adVM: AbyssDungeonVM) {
                         text = "3관문 ${adVM.ivoryTower.threePhase.level} : ${adVM.ivoryTower.threePhase.totalGold.formatWithCommas()} G",
                         color = Color.White
                     )
-                    Text(
-                        text = "4관문 ${adVM.ivoryTower.fourPhase.level} : ${adVM.ivoryTower.fourPhase.totalGold.formatWithCommas()} G",
-                        color = Color.White
-                    )
                 }
             )
         }
-
     }
 }
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/Common.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/Common.kt
@@ -69,7 +69,6 @@ fun RaidCard(
             phaseCard()
         }
     }
-
 }
 
 @Composable

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/Common.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/Common.kt
@@ -2,7 +2,6 @@ package com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -30,6 +29,7 @@ import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 import com.hongmyeoun.goldcalc.ui.theme.ImageBG
 import com.hongmyeoun.goldcalc.ui.theme.LightGrayBG
+import com.hongmyeoun.goldcalc.view.common.noRippleClickable
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
@@ -48,7 +48,7 @@ fun RaidCard(
                 rotationY = rotaR
                 cameraDistance = 8 * density
             }
-            .clickable { onClick() },
+            .noRippleClickable { onClick() },
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(
             defaultElevation = 6.dp

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/phase/SharedUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/phase/SharedUI.kt
@@ -32,6 +32,7 @@ import com.hongmyeoun.goldcalc.model.common.formatWithCommas
 import com.hongmyeoun.goldcalc.ui.theme.GreenQual
 import com.hongmyeoun.goldcalc.ui.theme.ImageBG
 import com.hongmyeoun.goldcalc.ui.theme.RedQual
+import com.hongmyeoun.goldcalc.ui.theme.YellowQual
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
@@ -261,7 +262,7 @@ fun Level(
     onLevelClicked: () -> Unit = {},
     oneDifficult: Boolean = false
 ) {
-    val difficultyColor = if (difficulty == "하드") RedQual else GreenQual
+    val difficultyColor = if (difficulty == "하드") RedQual else if (difficulty == "노말") GreenQual else YellowQual
 
     Row(
         modifier = Modifier

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/phase/SharedUI.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/phase/SharedUI.kt
@@ -33,6 +33,7 @@ import com.hongmyeoun.goldcalc.ui.theme.GreenQual
 import com.hongmyeoun.goldcalc.ui.theme.ImageBG
 import com.hongmyeoun.goldcalc.ui.theme.RedQual
 import com.hongmyeoun.goldcalc.ui.theme.YellowQual
+import com.hongmyeoun.goldcalc.view.common.noRippleClickable
 
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
@@ -220,7 +221,7 @@ fun ClearMoreCheckBox(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Row(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).noRippleClickable {  },
             verticalAlignment = Alignment.CenterVertically
         ) {
             Checkbox(
@@ -236,7 +237,7 @@ fun ClearMoreCheckBox(
         }
 
         Row(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).noRippleClickable {  },
             verticalAlignment = Alignment.CenterVertically
         ) {
             Checkbox(
@@ -267,6 +268,7 @@ fun Level(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .noRippleClickable {  }
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/raidContents/AbyssDungeon.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/raidContents/AbyssDungeon.kt
@@ -8,10 +8,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.hongmyeoun.goldcalc.R
-import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCheckBox
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCard
+import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCheckBox
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCheckLists
-import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.phase.FourPhase
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.phase.ThreePhase
 import com.hongmyeoun.goldcalc.viewModel.homework.AbyssDungeonVM
 
@@ -124,7 +123,7 @@ fun AbyssDungeon(viewModel: AbyssDungeonVM) {
             rotaR = ivoryTowerRotaR,
             onClick = { ivoryTowerRotated = !ivoryTowerRotated },
             phaseCard = {
-                FourPhase(
+                ThreePhase(
                     rotaR = ivoryTowerRotaR,
 
                     name = viewModel.ivoryTower.name,
@@ -179,23 +178,6 @@ fun AbyssDungeon(viewModel: AbyssDungeonVM) {
                     },
                     onThreePhaseSeeMoreCheckBoxChecked = {
                         viewModel.ivoryTower.threePhase.onSeeMoreCheckBoxClicked(it)
-                        viewModel.sumGold()
-                    },
-
-                    phaseFourLevel = viewModel.ivoryTower.fourPhase.level,
-                    phaseFourGold = viewModel.ivoryTower.fourPhase.totalGold,
-                    phaseFourSMC = viewModel.ivoryTower.fourPhase.seeMoreCheck,
-                    phaseFourCC = viewModel.ivoryTower.fourPhase.clearCheck,
-                    onFourPhaseLevelClicked = {
-                        viewModel.ivoryTower.fourPhase.onLevelClicked()
-                        viewModel.sumGold()
-                    },
-                    onFourPhaseClearCheckBoxChecked = {
-                        viewModel.ivoryTower.fourPhase.onClearCheckBoxClicked(it)
-                        viewModel.sumGold()
-                    },
-                    onFourPhaseSeeMoreCheckBoxChecked = {
-                        viewModel.ivoryTower.fourPhase.onSeeMoreCheckBoxClicked(it)
                         viewModel.sumGold()
                     }
                 )

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/raidContents/Command.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/homework/content/checkLists/raidCard/raidContents/Command.kt
@@ -8,13 +8,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.hongmyeoun.goldcalc.R
-import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCheckBox
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCard
+import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCheckBox
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.RaidCheckLists
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.phase.FourPhase
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.phase.FourPhaseLastHard
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.phase.ThreePhase
-import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.phase.ThreePhaseNoHard
 import com.hongmyeoun.goldcalc.view.homework.content.checkLists.raidCard.phase.TwoPhase
 import com.hongmyeoun.goldcalc.viewModel.homework.CommandBossVM
 
@@ -152,7 +151,6 @@ fun Command(
                         viewModel.sumGold()
                     },
                 )
-
             }
         )
     }
@@ -206,29 +204,32 @@ fun Command(
                         viewModel.sumGold()
                     },
                 )
-
             }
         )
     }
 
     if (viewModel.koukuCheck) {
-
         RaidCard(
             bossImg = R.drawable.command_kouku,
             isRotated = koukuSatonRotated,
             rotaR = koukuSatonRotaR,
             onClick = { koukuSatonRotated = !koukuSatonRotated },
             phaseCard = {
-                ThreePhaseNoHard(
+                ThreePhase(
                     rotaR = koukuSatonRotaR,
 
                     name = viewModel.koukuSaton.name,
                     raidBossImg = R.drawable.logo_saton,
                     totalGold = viewModel.koukuSaton.totalGold,
 
+                    phaseOneLevel = viewModel.koukuSaton.onePhase.level,
                     phaseOneGold = viewModel.koukuSaton.onePhase.totalGold,
                     phaseOneSMC = viewModel.koukuSaton.onePhase.seeMoreCheck,
                     phaseOneCC = viewModel.koukuSaton.onePhase.clearCheck,
+                    onOnePhaseLevelClicked = {
+                        viewModel.koukuSaton.onePhase.onLevelClicked()
+                        viewModel.sumGold()
+                    },
                     onOnePhaseClearCheckBoxChecked = {
                         viewModel.koukuSaton.onePhase.onClearCheckBoxClicked(it)
                         viewModel.sumGold()
@@ -238,9 +239,14 @@ fun Command(
                         viewModel.sumGold()
                     },
 
+                    phaseTwoLevel = viewModel.koukuSaton.twoPhase.level,
                     phaseTwoGold = viewModel.koukuSaton.twoPhase.totalGold,
                     phaseTwoSMC = viewModel.koukuSaton.twoPhase.seeMoreCheck,
                     phaseTwoCC = viewModel.koukuSaton.twoPhase.clearCheck,
+                    onTwoPhaseLevelClicked = {
+                        viewModel.koukuSaton.twoPhase.onLevelClicked()
+                        viewModel.sumGold()
+                    },
                     onTwoPhaseClearCheckBoxChecked = {
                         viewModel.koukuSaton.twoPhase.onClearCheckBoxClicked(it)
                         viewModel.sumGold()
@@ -250,9 +256,14 @@ fun Command(
                         viewModel.sumGold()
                     },
 
+                    phaseThreeLevel = viewModel.koukuSaton.threePhase.level,
                     phaseThreeGold = viewModel.koukuSaton.threePhase.totalGold,
                     phaseThreeSMC = viewModel.koukuSaton.threePhase.seeMoreCheck,
                     phaseThreeCC = viewModel.koukuSaton.threePhase.clearCheck,
+                    onThreePhaseLevelClicked = {
+                        viewModel.koukuSaton.threePhase.onLevelClicked()
+                        viewModel.sumGold()
+                    },
                     onThreePhaseClearCheckBoxChecked = {
                         viewModel.koukuSaton.threePhase.onClearCheckBoxClicked(it)
                         viewModel.sumGold()

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/home/HomeContentVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/home/HomeContentVM.kt
@@ -236,8 +236,7 @@ class HomeContentVM @Inject constructor(
         _ivoryTowerTG.value = when (nowPhase) {
             1 -> { _abModel.value.ivoryTower.onePhase.totalGold }
             2 -> { _abModel.value.ivoryTower.onePhase.totalGold + _abModel.value.ivoryTower.twoPhase.totalGold }
-            3 -> { _abModel.value.ivoryTower.onePhase.totalGold + _abModel.value.ivoryTower.twoPhase.totalGold + _abModel.value.ivoryTower.threePhase.totalGold }
-            4 -> { _abModel.value.ivoryTower.totalGold }
+            3 -> { _abModel.value.ivoryTower.totalGold }
             else -> { 0 }
         }
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/homework/HomeworkVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/homework/HomeworkVM.kt
@@ -358,11 +358,6 @@ class HomeworkVM @Inject constructor(
                                 isClear =  if (abyssDungeon.ivoryCheck) abyssDungeon.ivoryTower.threePhase.clearCheck else false,
                                 mCheck = if (abyssDungeon.ivoryCheck) abyssDungeon.ivoryTower.threePhase.seeMoreCheck else false,
                             ),
-                            originalCheckList.abyssDungeon[1].phases[3].copy( // 4페
-                                difficulty = abyssDungeon.ivoryTower.fourPhase.level,
-                                isClear =  if (abyssDungeon.ivoryCheck) abyssDungeon.ivoryTower.fourPhase.clearCheck else false,
-                                mCheck = if (abyssDungeon.ivoryCheck) abyssDungeon.ivoryTower.fourPhase.seeMoreCheck else false,
-                            ),
                         ),
                         isCheck = abyssDungeon.ivoryCheck
                     )


### PR DESCRIPTION
# 시즌 3 대비 업데이트
2024.07.10 로스트아크가 시즌 3가 되면서 컨텐츠 골드 너프 및 솔로잉 컨텐츠의 추가가 됨.
그로 인해 숙제 체크 페이지에 변화된 값을 변화해주고, 솔로잉 컨텐츠에 대한 보상도 입력할 수 있게 솔로잉 항목을 추가

## 추가된 값
![homework2](https://github.com/hongmyeoun/GoldCalc/assets/139526068/7f5bb47d-3a3e-445a-a399-2b151d26a011)

### 변경된 골드
- 군단장
    - 아브렐슈드(노말)
    - 더보기 : 400 -> 250, 600 -> 300, 800 -> 400, 1500 -> 600
    - 클리어 : 1500 -> 1000, 1500 -> 1000, 1500 -> 1000, 2500 -> 1600

    - 아브렐슈드(하드)
    - 더보기 : 700 -> 400, 900 -> 400, 1100 -> 500, 1800 -> 800
    - 클리어 : 2000 -> 1200, 2000 -> 1200, 2000 -> 1200, 3000 -> 2000

    - 일리아칸(노말)
    - 더보기 : 900 -> 450, 1100 -> 550, 1500 -> 750
    - 클리어 : 1500 -> 1000, 2000 -> 1800, 4000 -> 2600

    - 일리아칸(하드)
    - 더보기 : 1200 -> 600, 1400 -> 700, 1900 -> 950
    - 클리어 : 1750 -> 1500, 2500 == 2500, 5750 -> 3500

- 어비스 던전
    - 카양겔(노말)
    - 더보기 : 600 -> 300, 800 -> 400, 1000 -> 500
    - 클리어 : 1000 -> 800, 1500 -> 1200, 2000 -> 1600

    - 카양겔(하드)
    - 더보기 : 700 -> 350, 900 -> 500, 1100 -> 700
    - 클리어 : 1500 -> 1000, 2000 -> 1600, 3000 -> 2200

    - 상아탑(노말, 3관문 삭제)
    - 더보기 : 700 -> 600, 800 -> 650, 3관문 삭제, 1100 -> 1000
    - 클리어 : 1500 == 1500, 1750 -> 2000, 3관문 삭제, 3250 -> 3000

    - 상아탑(하드, 3관문 삭제)
    - 더보기 : 1000 -> 1200, 1750 -> 1450, 3관문 삭제, 2000 == 2000
    - 클리어 : 2000 -> 3000, 2500 -> 4000, 3관문 삭제, 6000 == 6000

### 솔로잉 예측
```
더보기 = 0
클리어 = (하드 - 노말) / 2
```
- 발탄
- 100, 150 -> 250

- 비아
- 150, 275 -> 425

- 쿠크
- 150, 200, 450 -> 800

- 아브렐슈드
- 375, 350, 300, 500 -> 1525

- 일리아칸
- 275, 575, 975 -> 1825

- 카양겔
- 250, 400, 550 -> 1100

- 상아탑
- 450, 675, 1000 -> 2125