### PR TITLE
fix : 아크패시브 활성화 튕김현상 수정

### DIFF
--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/Engravings.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/Engravings.kt
@@ -3,8 +3,9 @@ package com.hongmyeoun.goldcalc.model.profile.engravings
 import com.google.gson.annotations.SerializedName
 
 data class SkillEngravingsAndEffects(
-    @SerializedName("Engravings") val engravings: List<SkillEngraving?>? = null,
-    @SerializedName("Effects") val effect: List<SkillEffect>
+    @SerializedName("Engravings") val engravings: List<SkillEngraving?>?,
+    @SerializedName("Effects") val effect: List<SkillEffect>?,
+    @SerializedName("ArkPassiveEffects") val arkPassiveEffect: List<ArkPassiveEffects>?
 )
 
 data class SkillEngraving(
@@ -20,10 +21,20 @@ data class SkillEffect(
     @SerializedName("Description") val description: String,
 )
 
+data class ArkPassiveEffects(
+    @SerializedName("AbilityStoneLevel") val abilityStoneLevel: Int?,
+    @SerializedName("Grade") val grade: String,
+    @SerializedName("Level") val level: Int,
+    @SerializedName("Name") val name: String,
+    @SerializedName("Description") val description: String,
+)
+
 data class SkillEngravings(
     val awakenEngravingsPoint: String? = null,
     val name: String,
-    val icon: String,
     val level: String,
     val description: String,
+    val abilityStoneLevel: Int? = null,
+    val icon: String? = null,
+    val grade: String? = null,
 )

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/SkillEngravingsDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/SkillEngravingsDetail.kt
@@ -5,7 +5,20 @@ import com.hongmyeoun.goldcalc.model.constants.TooltipStrings
 
 class SkillEngravingsDetail(private val skillEngravings: SkillEngravingsAndEffects) {
     fun getEngravingsDetail(): List<SkillEngravings> {
-        val engravingMap = skillEngravings.engravings?.associateBy { it?.name }
+        if (skillEngravings.engravings.isNullOrEmpty() || skillEngravings.effect.isNullOrEmpty()) {
+            return skillEngravings.arkPassiveEffect?.map { passiveEffect ->
+                SkillEngravings(
+                    name = passiveEffect.name,
+                    level = passiveEffect.level.toString(),
+                    description = passiveEffect.description,
+                    abilityStoneLevel = passiveEffect.abilityStoneLevel,
+                    icon = null,
+                    grade = passiveEffect.grade
+                )
+            } ?: emptyList()
+        }
+
+        val engravingMap = skillEngravings.engravings.associateBy { it?.name }
 
         return skillEngravings.effect.map { effect ->
             val name = effect.name.substringBefore(TooltipStrings.SubStringBefore.SPACE_LEVEL)
@@ -16,13 +29,33 @@ class SkillEngravingsDetail(private val skillEngravings: SkillEngravingsAndEffec
                 description = removeHTMLTags(effect.description)
             )
 
-            engravingMap?.get(name)?.let { engraving ->
+            engravingMap[name]?.let { engraving ->
                 engravingDetail.copy(
                     awakenEngravingsPoint = getAwakenEngravingsPoint(engraving)
                 )
             } ?: engravingDetail
         }
     }
+
+//    fun getEngravingsDetail(): List<SkillEngravings> {
+//        val engravingMap = skillEngravings.engravings?.associateBy { it?.name }
+//
+//        return skillEngravings.effect?.map { effect ->
+//            val name = effect.name.substringBefore(TooltipStrings.SubStringBefore.SPACE_LEVEL)
+//            val engravingDetail = SkillEngravings(
+//                name = name,
+//                icon = effect.icon,
+//                level = effect.name.substringAfter(TooltipStrings.SubStringAfter.LEVEL_DOT_SPACE),
+//                description = removeHTMLTags(effect.description)
+//            )
+//
+//            engravingMap?.get(name)?.let { engraving ->
+//                engravingDetail.copy(
+//                    awakenEngravingsPoint = getAwakenEngravingsPoint(engraving)
+//                )
+//            } ?: engravingDetail
+//        } ?:
+//    }
 
     private fun getAwakenEngravingsPoint(skillEngraving: SkillEngraving): String {
         val tooltip = JsonParser.parseString(skillEngraving.tooltip).asJsonObject

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/equipment/Equipment.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/equipment/Equipment.kt
@@ -36,11 +36,13 @@ data class CharacterAccessory(
   val name: String,
   val itemQuality: Int,
   val itemIcon: String,
-  val combatStat1: String,
-  val combatStat2: String,
+  val combatStat1: String?,
+  val combatStat2: String?,
   val engraving1: String,
   val engraving2: String,
   val engraving3: String,
+  val grindEffect: String?,
+  val arkPassivePoint: String?
 ) : CharacterItem
 
 data class AbilityStone(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/accessory/Accessory.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/accessory/Accessory.kt
@@ -67,13 +67,13 @@ fun AccessoryUI(
                 viewModel = viewModel,
                 grade = accessory.grade
             )
-            if (accessory.combatStat1.isNotEmpty()) {
+            if (!accessory.combatStat1.isNullOrEmpty()) {
                 Column {
                     Text(
                         text = accessory.combatStat1,
                         style = normalTextStyle()
                     )
-                    if (accessory.combatStat2.isNotEmpty() && accessory.type == EquipmentConsts.NECKLACE) {
+                    if (!accessory.combatStat2.isNullOrEmpty() && accessory.type == EquipmentConsts.NECKLACE) {
                         Text(
                             text = accessory.combatStat2,
                             style = normalTextStyle()

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/detail/AccessoryDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/detail/AccessoryDetail.kt
@@ -1,9 +1,11 @@
 package com.hongmyeoun.goldcalc.view.profile.content.equipments.detail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -92,43 +94,74 @@ private fun DetailUI(
         )
         Spacer(modifier = Modifier.width(8.dp))
         Column {
-            Text(
-                text = accessory.name,
-                style = titleBoldWhite12()
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Row {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Text(
-                    text = accessory.combatStat1,
-                    style = normalTextStyle(fontSize = 12.sp)
+                    text = accessory.name,
+                    style = titleBoldWhite12()
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                if (accessory.type == EquipmentConsts.NECKLACE) {
-                    Text(
-                        text = accessory.combatStat2,
-                        style = normalTextStyle(fontSize = 12.sp)
+
+                if (accessory.arkPassivePoint != null) {
+                    TextChip(
+                        text = accessory.arkPassivePoint,
+                        customBGColor = LightGrayBG,
+                        borderless = true
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            Row {
-                TextChip(
-                    text = viewModel.simplyEngravingName(accessory.engraving1),
-                    customBGColor = LightGrayBG,
-                    borderless = true
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                TextChip(
-                    text = viewModel.simplyEngravingName(accessory.engraving2),
-                    customBGColor = LightGrayBG,
-                    borderless = true
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                TextChip(
-                    text = accessory.engraving3,
-                    customBGColor = RedQual,
-                    borderless = true
-                )
+            Spacer(modifier = Modifier.height(4.dp))
+
+            if (accessory.combatStat1 != null && accessory.combatStat2 != null) {
+                Row {
+                    Text(
+                        text = accessory.combatStat1,
+                        style = normalTextStyle(fontSize = 12.sp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    if (accessory.type == EquipmentConsts.NECKLACE) {
+                        Text(
+                            text = accessory.combatStat2,
+                            style = normalTextStyle(fontSize = 12.sp)
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Row {
+                    TextChip(
+                        text = viewModel.simplyEngravingName(accessory.engraving1),
+                        customBGColor = LightGrayBG,
+                        borderless = true
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextChip(
+                        text = viewModel.simplyEngravingName(accessory.engraving2),
+                        customBGColor = LightGrayBG,
+                        borderless = true
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextChip(
+                        text = accessory.engraving3,
+                        customBGColor = RedQual,
+                        borderless = true
+                    )
+                }
+            } else if (accessory.grindEffect != null) {
+                Box(
+                    modifier = Modifier
+                        .background(LightGrayBG, RoundedCornerShape(4.dp))
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    Text(
+                        text = accessory.grindEffect,
+                        style = normalTextStyle()
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/profile/EquipmentVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/profile/EquipmentVM.kt
@@ -89,16 +89,33 @@ class EquipmentVM(characterEquipment: List<CharacterItem>) : ViewModel() {
     }
 
 
-    private fun getSumCombatStat(equipment: List<CharacterItem>): Int {
-        val combatStat = equipment.filterIsInstance<CharacterAccessory>().map { it.combatStat1 }
-        if (combatStat.isNotEmpty()) {
-            val combatStatOne = combatStat.sumOf { it.split(" ")[1].removePrefix("+").toInt() }
-            val combatStatTwo = equipment.filterIsInstance<CharacterAccessory>()[0].combatStat2.split(" ")[1].removePrefix("+").toInt()
+//    private fun getSumCombatStat(equipment: List<CharacterItem>): Int {
+//        val combatStat = equipment.filterIsInstance<CharacterAccessory>().mapNotNull { it.combatStat1 }
+//        if (combatStat.isNotEmpty()) {
+//            val combatStatOne = combatStat.sumOf { it.split(" ")[1].removePrefix("+").toInt() }
+//            val combatStatTwo = equipment.filterIsInstance<CharacterAccessory>()[0].combatStat2.split(" ")[1].removePrefix("+").toInt()
+//
+//            return combatStatOne + combatStatTwo
+//        }
+//        return 0
+//    }
 
-            return combatStatOne + combatStatTwo
+    private fun getSumCombatStat(equipment: List<CharacterItem>): Int {
+        var combatStatOne = 0
+        var combatStatTwo = 0
+
+        equipment.filterIsInstance<CharacterAccessory>().forEach { accessory ->
+            accessory.combatStat1?.let {
+                combatStatOne += it.split(" ")[1].removePrefix("+").toIntOrNull() ?: 0
+            }
+            accessory.combatStat2?.let {
+                combatStatTwo += it.split(" ")[1].removePrefix("+").toIntOrNull() ?: 0
+            }
         }
-        return 0
+
+        return combatStatOne + combatStatTwo
     }
+
 
     fun setOptionName(equipment: CharacterEquipment): String {
         return equipment.setOption.split(" ").first()


### PR DESCRIPTION
작업 완료
Engravings에 ArkPassiveEffects가 추가됨

아크패시브 활성화시 악세서리
전투 스텟이 사라짐
각인 옵션이 사라짐
-> null 처리
연마 옵션이 생김
깨달음 포인트가 생김
-> 3티 이하는 없음, null 처리

작업 예정
검색시 튕기는 문제 해결
- 아크패시브 활성화 한 상태

아크패시브 활성화 문제
- 악세서리 표기 변경하기
- 어빌리티스톤 slicing 다시하기
- 팔찌 안뜨는 이유 찾기
- 세트옵션, 엘릭서 안뜨는 이유 찾기
- 각인 표기 변경

비활성화시
- 엘릭서 정보가 안뜨는 것 수정

메인
LazyColumn 목록과 HorizontalPager로 변경 가능하게 하기

빈값에 빈값인 이미지보여주기
-> list에서 find로 찾고 없다면 빈값, 있다면 채우기 이런식?
(나중에) 팔찌 상중하 옵션별로 색부여

코드 전체
공통 함수 정리 및 viewModel 정리
viewModel에서 사용되는 공통 함수 model로 빼기