### PR TITLE
Fix little problem

### DIFF
--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/constants/ErrorMessage.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/constants/ErrorMessage.kt
@@ -4,6 +4,8 @@ object ErrorMessage {
     const val ERROR_503 = "서버 응답 실패: 503"
     const val ERROR_503_MESSAGE = "서버 점검중 입니다 ㅠㅠ"
     const val NO = "없는"
+    const val SEASON_3_NO_RECENT_CONNECT = "최근 캐릭터 접속 기록이 없습니다."
+    const val RECONNECT = "게임에 접속해 주세요."
 
     fun noResult(input: String): String {
         return "\"${input}\"(은)는 없는 결과입니다."

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/constants/raid/Gold.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/constants/raid/Gold.kt
@@ -35,14 +35,14 @@ class Gold {
         }
 
         object Solo {
-            val VALTAN = listOf(0, 0)
-            val BIACKISS = listOf(0, 0)
-            val KOUKU_SATON = listOf(0, 0, 0)
-            val ABRELSHUD = listOf(0, 0, 0, 0)
-            val ILLIAKAN = listOf(0, 0, 0)
+            val VALTAN = listOf(75, 100)
+            val BIACKISS = listOf(100, 150)
+            val KOUKU_SATON = listOf(100, 150, 200)
+            val ABRELSHUD = listOf(100, 150, 200, 375)
+            val ILLIAKAN = listOf(225, 275, 375)
 
-            val KAYANGEL = listOf(0, 0, 0)
-            val IVORY_TOWER = listOf(0, 0, 0)
+            val KAYANGEL = listOf(200, 225, 300)
+            val IVORY_TOWER = listOf(250, 350, 550)
         }
     }
 

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/Engravings.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/Engravings.kt
@@ -3,8 +3,9 @@ package com.hongmyeoun.goldcalc.model.profile.engravings
 import com.google.gson.annotations.SerializedName
 
 data class SkillEngravingsAndEffects(
-    @SerializedName("Engravings") val engravings: List<SkillEngraving?>? = null,
-    @SerializedName("Effects") val effect: List<SkillEffect>
+    @SerializedName("Engravings") val engravings: List<SkillEngraving?>?,
+    @SerializedName("Effects") val effect: List<SkillEffect>?,
+    @SerializedName("ArkPassiveEffects") val arkPassiveEffect: List<ArkPassiveEffects>?
 )
 
 data class SkillEngraving(
@@ -20,10 +21,20 @@ data class SkillEffect(
     @SerializedName("Description") val description: String,
 )
 
+data class ArkPassiveEffects(
+    @SerializedName("AbilityStoneLevel") val abilityStoneLevel: Int?,
+    @SerializedName("Grade") val grade: String,
+    @SerializedName("Level") val level: Int,
+    @SerializedName("Name") val name: String,
+    @SerializedName("Description") val description: String,
+)
+
 data class SkillEngravings(
     val awakenEngravingsPoint: String? = null,
     val name: String,
-    val icon: String,
     val level: String,
     val description: String,
+    val abilityStoneLevel: Int? = null,
+    val icon: String? = null,
+    val grade: String? = null,
 )

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/SkillEngravingsDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/engravings/SkillEngravingsDetail.kt
@@ -5,7 +5,20 @@ import com.hongmyeoun.goldcalc.model.constants.TooltipStrings
 
 class SkillEngravingsDetail(private val skillEngravings: SkillEngravingsAndEffects) {
     fun getEngravingsDetail(): List<SkillEngravings> {
-        val engravingMap = skillEngravings.engravings?.associateBy { it?.name }
+        if (skillEngravings.engravings.isNullOrEmpty() || skillEngravings.effect.isNullOrEmpty()) {
+            return skillEngravings.arkPassiveEffect?.map { passiveEffect ->
+                SkillEngravings(
+                    name = passiveEffect.name,
+                    level = passiveEffect.level.toString(),
+                    description = passiveEffect.description,
+                    abilityStoneLevel = passiveEffect.abilityStoneLevel,
+                    icon = null,
+                    grade = passiveEffect.grade
+                )
+            } ?: emptyList()
+        }
+
+        val engravingMap = skillEngravings.engravings.associateBy { it?.name }
 
         return skillEngravings.effect.map { effect ->
             val name = effect.name.substringBefore(TooltipStrings.SubStringBefore.SPACE_LEVEL)
@@ -16,13 +29,33 @@ class SkillEngravingsDetail(private val skillEngravings: SkillEngravingsAndEffec
                 description = removeHTMLTags(effect.description)
             )
 
-            engravingMap?.get(name)?.let { engraving ->
+            engravingMap[name]?.let { engraving ->
                 engravingDetail.copy(
                     awakenEngravingsPoint = getAwakenEngravingsPoint(engraving)
                 )
             } ?: engravingDetail
         }
     }
+
+//    fun getEngravingsDetail(): List<SkillEngravings> {
+//        val engravingMap = skillEngravings.engravings?.associateBy { it?.name }
+//
+//        return skillEngravings.effect?.map { effect ->
+//            val name = effect.name.substringBefore(TooltipStrings.SubStringBefore.SPACE_LEVEL)
+//            val engravingDetail = SkillEngravings(
+//                name = name,
+//                icon = effect.icon,
+//                level = effect.name.substringAfter(TooltipStrings.SubStringAfter.LEVEL_DOT_SPACE),
+//                description = removeHTMLTags(effect.description)
+//            )
+//
+//            engravingMap?.get(name)?.let { engraving ->
+//                engravingDetail.copy(
+//                    awakenEngravingsPoint = getAwakenEngravingsPoint(engraving)
+//                )
+//            } ?: engravingDetail
+//        } ?:
+//    }
 
     private fun getAwakenEngravingsPoint(skillEngraving: SkillEngraving): String {
         val tooltip = JsonParser.parseString(skillEngraving.tooltip).asJsonObject

--- a/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/equipment/Equipment.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/model/profile/equipment/Equipment.kt
@@ -36,11 +36,13 @@ data class CharacterAccessory(
   val name: String,
   val itemQuality: Int,
   val itemIcon: String,
-  val combatStat1: String,
-  val combatStat2: String,
+  val combatStat1: String?,
+  val combatStat2: String?,
   val engraving1: String,
   val engraving2: String,
   val engraving3: String,
+  val grindEffect: String?,
+  val arkPassivePoint: String?
 ) : CharacterItem
 
 data class AbilityStone(

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/Content.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/Content.kt
@@ -1,19 +1,25 @@
 package com.hongmyeoun.goldcalc.view.profile.content
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.hongmyeoun.goldcalc.model.constants.ErrorMessage.RECONNECT
+import com.hongmyeoun.goldcalc.model.constants.ErrorMessage.SEASON_3_NO_RECENT_CONNECT
 import com.hongmyeoun.goldcalc.model.lostArkApi.SearchedCharacterDetail
 import com.hongmyeoun.goldcalc.ui.theme.ImageBG
 import com.hongmyeoun.goldcalc.view.common.profileTemplate.ProfileTemplate
@@ -22,6 +28,7 @@ import com.hongmyeoun.goldcalc.view.profile.content.engraving.Engraving
 import com.hongmyeoun.goldcalc.view.profile.content.equipments.Equipments
 import com.hongmyeoun.goldcalc.view.profile.content.gem.Gem
 import com.hongmyeoun.goldcalc.view.profile.content.skill.Skill
+import com.hongmyeoun.goldcalc.view.profile.titleTextStyle
 import com.hongmyeoun.goldcalc.viewModel.profile.ProfileVM
 
 @Composable
@@ -61,6 +68,8 @@ fun ProfileContent(
                 profile = profile
             )
         }
+    } ?: run {
+        NoCharacter(paddingValues = paddingValues)
     }
 }
 
@@ -84,6 +93,27 @@ fun ProfileDetails(
         Skill(
             viewModel = viewModel,
             profile = profile
+        )
+    }
+}
+
+@Composable
+fun NoCharacter(paddingValues: PaddingValues) {
+    Column(
+        modifier = Modifier
+            .padding(paddingValues)
+            .fillMaxSize()
+            .background(ImageBG),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = SEASON_3_NO_RECENT_CONNECT,
+            style = titleTextStyle(fontSize = 15.sp)
+        )
+        Text(
+            text = RECONNECT,
+            style = titleTextStyle(fontSize = 15.sp)
         )
     }
 }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/accessory/Accessory.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/accessory/Accessory.kt
@@ -67,13 +67,13 @@ fun AccessoryUI(
                 viewModel = viewModel,
                 grade = accessory.grade
             )
-            if (accessory.combatStat1.isNotEmpty()) {
+            if (!accessory.combatStat1.isNullOrEmpty()) {
                 Column {
                     Text(
                         text = accessory.combatStat1,
                         style = normalTextStyle()
                     )
-                    if (accessory.combatStat2.isNotEmpty() && accessory.type == EquipmentConsts.NECKLACE) {
+                    if (!accessory.combatStat2.isNullOrEmpty() && accessory.type == EquipmentConsts.NECKLACE) {
                         Text(
                             text = accessory.combatStat2,
                             style = normalTextStyle()

--- a/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/detail/AccessoryDetail.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/view/profile/content/equipments/detail/AccessoryDetail.kt
@@ -1,9 +1,11 @@
 package com.hongmyeoun.goldcalc.view.profile.content.equipments.detail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -92,43 +94,74 @@ private fun DetailUI(
         )
         Spacer(modifier = Modifier.width(8.dp))
         Column {
-            Text(
-                text = accessory.name,
-                style = titleBoldWhite12()
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Row {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Text(
-                    text = accessory.combatStat1,
-                    style = normalTextStyle(fontSize = 12.sp)
+                    text = accessory.name,
+                    style = titleBoldWhite12()
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                if (accessory.type == EquipmentConsts.NECKLACE) {
-                    Text(
-                        text = accessory.combatStat2,
-                        style = normalTextStyle(fontSize = 12.sp)
+
+                if (accessory.arkPassivePoint != null) {
+                    TextChip(
+                        text = accessory.arkPassivePoint,
+                        customBGColor = LightGrayBG,
+                        borderless = true
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            Row {
-                TextChip(
-                    text = viewModel.simplyEngravingName(accessory.engraving1),
-                    customBGColor = LightGrayBG,
-                    borderless = true
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                TextChip(
-                    text = viewModel.simplyEngravingName(accessory.engraving2),
-                    customBGColor = LightGrayBG,
-                    borderless = true
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                TextChip(
-                    text = accessory.engraving3,
-                    customBGColor = RedQual,
-                    borderless = true
-                )
+            Spacer(modifier = Modifier.height(4.dp))
+
+            if (accessory.combatStat1 != null && accessory.combatStat2 != null) {
+                Row {
+                    Text(
+                        text = accessory.combatStat1,
+                        style = normalTextStyle(fontSize = 12.sp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    if (accessory.type == EquipmentConsts.NECKLACE) {
+                        Text(
+                            text = accessory.combatStat2,
+                            style = normalTextStyle(fontSize = 12.sp)
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Row {
+                    TextChip(
+                        text = viewModel.simplyEngravingName(accessory.engraving1),
+                        customBGColor = LightGrayBG,
+                        borderless = true
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextChip(
+                        text = viewModel.simplyEngravingName(accessory.engraving2),
+                        customBGColor = LightGrayBG,
+                        borderless = true
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    TextChip(
+                        text = accessory.engraving3,
+                        customBGColor = RedQual,
+                        borderless = true
+                    )
+                }
+            } else if (accessory.grindEffect != null) {
+                Box(
+                    modifier = Modifier
+                        .background(LightGrayBG, RoundedCornerShape(4.dp))
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    Text(
+                        text = accessory.grindEffect,
+                        style = normalTextStyle()
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/profile/EquipmentVM.kt
+++ b/app/src/main/java/com/hongmyeoun/goldcalc/viewModel/profile/EquipmentVM.kt
@@ -89,16 +89,33 @@ class EquipmentVM(characterEquipment: List<CharacterItem>) : ViewModel() {
     }
 
 
-    private fun getSumCombatStat(equipment: List<CharacterItem>): Int {
-        val combatStat = equipment.filterIsInstance<CharacterAccessory>().map { it.combatStat1 }
-        if (combatStat.isNotEmpty()) {
-            val combatStatOne = combatStat.sumOf { it.split(" ")[1].removePrefix("+").toInt() }
-            val combatStatTwo = equipment.filterIsInstance<CharacterAccessory>()[0].combatStat2.split(" ")[1].removePrefix("+").toInt()
+//    private fun getSumCombatStat(equipment: List<CharacterItem>): Int {
+//        val combatStat = equipment.filterIsInstance<CharacterAccessory>().mapNotNull { it.combatStat1 }
+//        if (combatStat.isNotEmpty()) {
+//            val combatStatOne = combatStat.sumOf { it.split(" ")[1].removePrefix("+").toInt() }
+//            val combatStatTwo = equipment.filterIsInstance<CharacterAccessory>()[0].combatStat2.split(" ")[1].removePrefix("+").toInt()
+//
+//            return combatStatOne + combatStatTwo
+//        }
+//        return 0
+//    }
 
-            return combatStatOne + combatStatTwo
+    private fun getSumCombatStat(equipment: List<CharacterItem>): Int {
+        var combatStatOne = 0
+        var combatStatTwo = 0
+
+        equipment.filterIsInstance<CharacterAccessory>().forEach { accessory ->
+            accessory.combatStat1?.let {
+                combatStatOne += it.split(" ")[1].removePrefix("+").toIntOrNull() ?: 0
+            }
+            accessory.combatStat2?.let {
+                combatStatTwo += it.split(" ")[1].removePrefix("+").toIntOrNull() ?: 0
+            }
         }
-        return 0
+
+        return combatStatOne + combatStatTwo
     }
+
 
     fun setOptionName(equipment: CharacterEquipment): String {
         return equipment.setOption.split(" ").first()


### PR DESCRIPTION
# 아크 패시브 활성화 튕김문제 임시조치
## 시즌3 오픈 이후 접속기록이 없는 캐릭은 검색상세 결과가 나오지 않게 변경
## 솔로잉 골드 더보기 값을 변경
## 아크패시브 활성화시 캐릭터 검색상세가 나오지 않고 튕겼던 문제 해결
### 임시조치이므로 각인, 패시브 등 다양한 값이 누락되건 비정상적으로 표기되어있습니다.
